### PR TITLE
Update nime2016.bib

### DIFF
--- a/BibTeX/nime2016.bib
+++ b/BibTeX/nime2016.bib
@@ -1404,7 +1404,7 @@
 
 @InProceedings{Lindell2016,
   Title                    = {Materiality for Musical Expressions: an Approach to Interdisciplinary Syllabus Development for NIME},
-  Author                   = {Rikard Lindell and Koray Tahiro\u{g}lu and Morten Riis and Jennie Schaeffer},
+  Author                   = {Rikard Lindell and Koray Tahiro{\u{g}}lu and Morten Riis and Jennie Schaeffer},
   Booktitle                = {Proceedings of the International Conference on New Interfaces for Musical Expression},
   Year                     = {2016},
 
@@ -2327,7 +2327,7 @@
 
 @InProceedings{Tahironicode287lu2016,
   Title                    = {Non-intrusive Counter-actions: Maintaining Progressively Engaging Interactions for Music Performance},
-  Author                   = {Koray Tahiro\u{g}lu and Juan Carlos Vasquez and Johan Kildal},
+  Author                   = {Koray Tahiro{\u{g}}lu and Juan Carlos Vasquez and Johan Kildal},
   Booktitle                = {Proceedings of the International Conference on New Interfaces for Musical Expression},
   Year                     = {2016},
 


### PR DESCRIPTION
seems like when nime archive website pulls the proceedings from github it does not display my surname which is written in latext as Tahiro\u{g}lu. It appears as T. g. I was wondering if  Tahiro{\u{g}}lu could help