### PR TITLE
Space between words for Pin&Play&Perform, brackets for months

### DIFF
--- a/BibTeX/nime.bib
+++ b/BibTeX/nime.bib
@@ -3479,7 +3479,7 @@ author outlines the algorithm used to choose and display aparticular excerpt and
 }
 
 @InProceedings{Bowers2006,
-  Title                    = {Creating Ad Hoc Instruments with Pin\&Play\&Perform},
+  Title                    = {Creating Ad Hoc Instruments with Pin \& Play \& Perform},
   Author                   = {Bowers, John and Villar, Nicolas},
   Booktitle                = {Proceedings of the International Conference on New Interfaces for Musical Expression},
   Year                     = {2006},
@@ -15874,7 +15874,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {94--97},
   Publisher                = {Goldsmiths, University of London},
 
@@ -15889,7 +15889,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {529--532},
   Publisher                = {Goldsmiths, University of London},
 
@@ -15904,7 +15904,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {84--85},
   Publisher                = {Goldsmiths, University of London},
 
@@ -15919,7 +15919,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {589--592},
   Publisher                = {Goldsmiths, University of London},
 
@@ -15934,7 +15934,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {155--158},
   Publisher                = {Goldsmiths, University of London},
 
@@ -15949,7 +15949,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {140--143},
   Publisher                = {Goldsmiths, University of London},
 
@@ -15964,7 +15964,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {311--314},
   Publisher                = {Goldsmiths, University of London},
 
@@ -15979,7 +15979,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {323--326},
   Publisher                = {Goldsmiths, University of London},
 
@@ -15994,7 +15994,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {499--500},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16009,7 +16009,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {7--12},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16024,7 +16024,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {175--178},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16039,7 +16039,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {13--18},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16054,7 +16054,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {315--318},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16069,7 +16069,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {163--166},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16084,7 +16084,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {144--146},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16099,7 +16099,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {363--366},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16114,7 +16114,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {391--394},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16129,7 +16129,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {355--358},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16144,7 +16144,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {513--516},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16159,7 +16159,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {201--206},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16174,7 +16174,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {114--117},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16189,7 +16189,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {403--406},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16204,7 +16204,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {541--544},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16219,7 +16219,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {407--410},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16234,7 +16234,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {569--572},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16249,7 +16249,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {78--79},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16264,7 +16264,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {351--354},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16279,7 +16279,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {134--135},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16294,7 +16294,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {593--596},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16309,7 +16309,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {491--494},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16324,7 +16324,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {35--39},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16339,7 +16339,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {86--87},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16354,7 +16354,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {287--292},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16369,7 +16369,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {281--286},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16384,7 +16384,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {343--346},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16399,7 +16399,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {427--430},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16414,7 +16414,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {151--154},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16429,7 +16429,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {581--584},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16444,7 +16444,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {1--6},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16459,7 +16459,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {577--580},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16474,7 +16474,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {487--490},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16489,7 +16489,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {625--628},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16504,7 +16504,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {371--374},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16519,7 +16519,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {383--386},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16534,7 +16534,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {347--350},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16549,7 +16549,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {597--600},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16564,7 +16564,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {443--448},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16579,7 +16579,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {411--414},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16594,7 +16594,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {66--69},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16609,7 +16609,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {277--280},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16624,7 +16624,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {431--434},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16639,7 +16639,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {74--77},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16654,7 +16654,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {461--466},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16669,7 +16669,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {88--89},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16684,7 +16684,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {46--49},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16699,7 +16699,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {497--498},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16714,7 +16714,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {339--342},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16729,7 +16729,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {483--486},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16744,7 +16744,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {217--220},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16760,7 +16760,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {367--370},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16775,7 +16775,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {335--338},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16790,7 +16790,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {557--560},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16805,7 +16805,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {233--238},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16820,7 +16820,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {102--105},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16835,7 +16835,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {293--298},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16850,7 +16850,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {273--276},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16865,7 +16865,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {327--330},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16880,7 +16880,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {50--53},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16895,7 +16895,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {545--548},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16910,7 +16910,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {191--194},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16925,7 +16925,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {303--306},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16940,7 +16940,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {319--322},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16955,7 +16955,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {60--65},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16970,7 +16970,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {263--268},
   Publisher                = {Goldsmiths, University of London},
 
@@ -16985,7 +16985,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {533--536},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17000,7 +17000,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {573--576},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17015,7 +17015,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {479--482},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17030,7 +17030,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {98--101},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17045,7 +17045,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {19--22},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17060,7 +17060,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {110--113},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17075,7 +17075,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {509--512},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17090,7 +17090,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {525--528},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17105,7 +17105,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {415--420},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17120,7 +17120,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {187--190},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17135,7 +17135,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {553--556},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17150,7 +17150,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {29--34},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17165,7 +17165,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {379--382},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17180,7 +17180,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {251--256},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17195,7 +17195,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {23--28},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17210,7 +17210,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {467--472},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17225,7 +17225,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {126--129},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17240,7 +17240,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {565--568},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17255,7 +17255,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {307--310},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17270,7 +17270,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {213--216},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17285,7 +17285,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {80--81},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17300,7 +17300,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {221--226},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17315,7 +17315,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {387--390},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17330,7 +17330,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {299--302},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17345,7 +17345,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {122--125},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17360,7 +17360,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {54--59},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17375,7 +17375,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {605--608},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17390,7 +17390,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {399--402},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17405,7 +17405,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {359--362},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17420,7 +17420,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {82--83},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17435,7 +17435,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {501--504},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17450,7 +17450,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {136--139},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17465,7 +17465,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {395--398},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17480,7 +17480,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {495--496},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17495,7 +17495,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {269--272},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17510,7 +17510,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {239--242},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17525,7 +17525,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {517--520},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17540,7 +17540,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {243--246},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17555,7 +17555,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {331--334},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17570,7 +17570,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {106--109},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17585,7 +17585,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {195--200},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17600,7 +17600,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {179--182},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17615,7 +17615,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {439--442},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17630,7 +17630,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {247--250},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17645,7 +17645,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {521--524},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17660,7 +17660,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {585--588},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17675,7 +17675,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {147--150},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17690,7 +17690,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {70--73},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17705,7 +17705,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {183--186},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17720,7 +17720,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {171--174},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17735,7 +17735,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {90--93},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17750,7 +17750,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {257--262},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17765,7 +17765,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {609--614},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17780,7 +17780,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {207--212},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17795,7 +17795,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {615--620},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17810,7 +17810,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {537--540},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17825,7 +17825,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {118--121},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17840,7 +17840,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {159--162},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17855,7 +17855,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {421--426},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17870,7 +17870,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {227--232},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17885,7 +17885,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {561--564},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17900,7 +17900,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {130--133},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17915,7 +17915,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {601--604},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17930,7 +17930,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {505--508},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17945,7 +17945,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {449--454},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17960,7 +17960,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {621--624},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17975,7 +17975,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {549--552},
   Publisher                = {Goldsmiths, University of London},
 
@@ -17990,7 +17990,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {435--438},
   Publisher                = {Goldsmiths, University of London},
 
@@ -18005,7 +18005,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {40--45},
   Publisher                = {Goldsmiths, University of London},
 
@@ -18020,7 +18020,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {629--632},
   Publisher                = {Goldsmiths, University of London},
 
@@ -18035,7 +18035,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {375--378},
   Publisher                = {Goldsmiths, University of London},
 
@@ -18050,7 +18050,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {167--170},
   Publisher                = {Goldsmiths, University of London},
 
@@ -18065,7 +18065,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {455--460},
   Publisher                = {Goldsmiths, University of London},
 
@@ -18080,7 +18080,7 @@ This project is relevant to a contemporary discourse on musical expression becau
   Year                     = {2014},
 
   Address                  = {London, United Kingdom},
-  Month                    = June,
+  Month                    = {June},
   Pages                    = {473--478},
   Publisher                = {Goldsmiths, University of London},
 


### PR DESCRIPTION
Brackets for months were causing errors in Latex
Lack of spaces for Pin&Play&Perform was causing overflowing text.