### PR TITLE
nime2004.bib: Add missing abstracts and fix some abstract typos

### DIFF
--- a/paper_proceedings/nime2004.bib
+++ b/paper_proceedings/nime2004.bib
@@ -19,6 +19,7 @@
   Address                  = {Hamamatsu, Japan},
   Pages                    = {27--30},
   Keywords                 = {collaboration,composition,improvisation,music},
+  Abstract                 = {We have seen many new and exciting developments in new interfaces for musical expression. In this paper we present the design of an interface for remote group music improvisation and composition - Daisyphone. The approach relies on players creating and editing short shared loops of music which are semi-synchronously updated. The interface emphasizes the looping nature of the music and is designed to be engaging and deployable on a wide range of interaction devices. Observations of the use of the tool with different levels of persistence of contribution are reported and discussed. Future developments centre around ways to string loops together into larger pieces (composition) and investigating suitable rates of decay to encourage more group improvisation.},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_027.pdf},
   DOI                      = {10.5281/zenodo.1176583}
 }
@@ -30,9 +31,7 @@
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {193--196},
-  Abstract                 = {This paper describes a theory for modulated objects based onobservations of recent musical interface design trends. Thetheory implies extensions to an object-based approach tocontroller design. Combining NIME research withethnographic study of shamanic traditions. The ,
-,
-authordiscusses the creation of new controllers based on theshamanic use of ritual objects.},
+  Abstract                 = {This paper describes a theory for modulated objects based on observations of recent musical interface design trends. The theory implies extensions to an object-based approach to controller design. Combining NIME research with ethnographic study of shamanic traditions. The author discusses the creation of new controllers based on the shamanic use of ritual objects.},
   Keywords                 = {Music and Video Controllers, New Interface Design, Music Composition, Multimedia, Mythology, Shamanism, Ecoacoustics},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_193.pdf},
   DOI                      = {10.5281/zenodo.1176585}
@@ -84,6 +83,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {132--137},
+  Abstract                 = {Real-time interactive software can be difficult to construct and debug. Aura is a software platform to facilitate highly interactive systems that combine audio signal processing, sophisticated control, sensors, computer animation, video processing, and graphical user interfaces. Moreover, Aura is open-ended, allowing diverse software components to be interconnected in a real-time framework. A recent assessment of Aura has motivated a redesign of the communication system to support remote procedure call. In addition, the audio signal processing framework has been altered to reduce programming errors. The motivation behind these changes is discussed, and measurements of run-time performance offer some general insights for system designers.},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_132.pdf},
   DOI                      = {10.5281/zenodo.1176593}
 }
@@ -121,7 +121,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {165--168},
-  Abstract                 = { This paper begins by evaluating various systems in terms of factors for building interactive audiovisual environments. The main issues for flexibility and expressiveness in the generation of dynamic sounds and images are then isolated. The design and development of an audiovisual system prototype is described at the end. },
+  Abstract                 = {This paper begins by evaluating various systems in terms of factors for building interactive audiovisual environments. The main issues for flexibility and expressiveness in the generation of dynamic sounds and images are then isolated. The design and development of an audiovisual system prototype is described at the end. },
   Keywords                 = {Audiovisual, composition, performance, gesture, image, representation, mapping, expressiveness.},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_165.pdf},
   DOI                      = {10.5281/zenodo.1176599}
@@ -199,6 +199,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {120--123},
+  Abstract                 = {Rencon is an annual international event that started in 2002. It has roles of (1) pursuing evaluation methods for systems whose output includes subjective issues, and (2) providing a forum for researches of several fields related to musical expression. In the past. Rencon was held as a workshop associated with a musical contest that provided a forum for presenting and discussing the latest research in automatic performance rendering. This year we introduce new evaluation methods of performance expression to Rencon: a Turing Test and a Gnirut Test, which is a reverse Turing Test, for performance expression. We have opened a section of the contests to any instruments and genre of music, including synthesized human voices.},
   Keywords                 = {Rencon, Turing Test, Musical Expression, Performance Rendering},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_120.pdf},
   DOI                      = {10.5281/zenodo.1176611}
@@ -237,6 +238,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {177--180},
+  Abstract                 = {In this paper, we describe a novel improvisation supporting system based on correcting musically unnatural melodies. Since improvisation is the musical performance style that involves creating melodies while playing, it is not easy even for the people who can play musical instruments. However, previous studies have not dealt with improvisation support for the people who can play musical instruments but cannot improvise. In this study, to support such players' improvisation, we propose a novel improvisation supporting system called ism, which corrects musically unnatural melodies automatically. The main issue in realizing this system is how to detect notes to be corrected (i.e., musically unnatural or inappropriate). We propose a method for detecting notes to be corrected based on the N-gram model. This method first calculates N-gram probabilities of played notes, and then judges notes with low N-gram probabilities to be corrected. Experimental results show that the N-gram-based melody correction and the proposed system are useful for supporting improvisation.},
   Keywords                 = {Improvisation support, jam session, melody correction, N-gram model, melody modeling, musical instrument},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_177.pdf},
   DOI                      = {10.5281/zenodo.1176617}
@@ -314,7 +316,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {68--73},
-  Abstract                 = {This paper describes the first system designed to allow children to conduct an audio and video recording of an orchestra. No prior music experience is required to control theorchestra, and the system uses an advanced algorithm totime stretch the audio in real-time at high quality and without altering the pitch. We will discuss the requirements andchallenges of designing an interface to target our particularuser group (children), followed by some system implementation details. An overview of the algorithm used for audiotime stretching will also be presented. We are currently using this technology to study and compare professional andnon-professional conducting behavior, and its implicationswhen designing new interfaces for multimedia. You're theConductor is currently a successful exhibit at the Children'sMuseum in Boston, USA.},
+  Abstract                 = {This paper describes the first system designed to allow children to conduct an audio and video recording of an orchestra. No prior music experience is required to control the orchestra, and the system uses an advanced algorithm to time stretch the audio in real-time at high quality and without altering the pitch. We will discuss the requirements and challenges of designing an interface to target our particular user group (children), followed by some system implementation details. An overview of the algorithm used for audio time stretching will also be presented. We are currently using this technology to study and compare professional and non-professional conducting behavior, and its implications when designing new interfaces for multimedia. You're the Conductor is currently a successful exhibit at the Children's Museum in Boston, USA.},
   Keywords                 = {conducting systems,design patterns,gesture recogni-,interactive exhibits,real-time audio stretching,tion},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_068.pdf},
   DOI                      = {10.5281/zenodo.1176629}
@@ -391,6 +393,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {173--176},
+  Abstract                 = {In this paper, I would like to introduce my experimental study of multimedia psychology. My initial focus of investigation is the interaction between perceptions of auditory and visual beats. When the musical and graphical beats are completely synchronized with each other, as in a music video for promotional purposes, the audience feels that they are natural and comforting. My initial experiment has proved that the actual tempos of music and images are a little different. If a slight timelag exists between the musical and pictorial beats, the audience tries to keep them in synchronization by unconsciously changing the interpretation of the time-based beat points. As the lag increases over time, the audience seems to perceive that the beat synchronization has changed from being more downbeat to more upbeat, and continues enjoying it. I have developed an experiment system that can generateand control out-of-phase visual and auditory beats in real time, and have tested many subjects with it. This paper describes the measurement of time lags generated in the experiment system, as part of my psychological experiment.},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_173.pdf},
   DOI                      = {10.5281/zenodo.1176641}
 }
@@ -402,6 +405,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {35--38},
+  Abstract                 = {Although MIDI is often used for computer-based interactive music applications, its real-time performance is rarely quantified, despite concerns about whether it is capable of adequate performance in realistic settings. We extend existing proposals for MIDI performance benchmarking so they are useful in realistic interactive scenarios, including those with heavy MIDI traffic and CPU load. We have produced a cross-platform freely-available testing suite that is easy to use, and have used it to survey the interactive performance of several commonly-used computer/MIDI setups. We describe the suite, summarize the results of our performance survey, and detail the benefits of this testing methodology.},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_035.pdf},
   DOI                      = {10.5281/zenodo.1176643}
 }
@@ -426,6 +430,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {80--86},
+  Abstract                 = {New Interfaces for Musical Expression must speak to the nature of 'instrument', that is, it must always be understood that the interface binds to a complex musical phenomenon. This paper explores the nature of engagement, the point of performance that occurs when a human being engages with a computer based instrument. It asks questions about the nature of the instrument in computer music and offers some conceptual models for the mapping of gesture to sonic outcomes.},
   Keywords                 = {dynamic,dynamic morphology,gesture,interaction,mapping,mind,music,orchestration,spectral morphology},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_080.pdf},
   DOI                      = {10.5281/zenodo.1176649}
@@ -451,6 +456,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {197--198},
+  Abstract                 = {In this paper, I will describe a computer vision-based musical performance system that uses morphological assessments to provide control data. Using shape analysis allows the system to provide qualitative descriptors of the scene being captured while ensuring its use in a wide variety of different settings. This system was implemented under Max/MSP/Jitter, augmented with a number of external objects. (1)},
   Keywords                 = {computer vision,image analysis,maxmsp,morphology,musical},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_197.pdf},
   DOI                      = {10.5281/zenodo.1176653}
@@ -463,7 +469,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {150--153},
-  Abstract                 = {A system is introduced that allows a string player to control asynthesis engine with the gestural skills he is used to. Theimplemented system is based on an electric viola and asynthesis engine that is directly controlled by the unanalysedaudio signal of the instrument and indirectly by controlparameters mapped to the synthesis engine. This method offersa highly string-specific playability, as it is sensitive to thekinds of musical articulation produced by traditional playingtechniques. Nuances of sound variation applied by the playerwill be present in the output signal even if those nuances arebeyond traditionally measurable parameters like pitch,amplitude or brightness. The relatively minimal hardwarerequirements make the instrument accessible with littleexpenditure.},
+  Abstract                 = {A system is introduced that allows a string player to control a synthesis engine with the gestural skills he is used to. The implemented system is based on an electric viola and a synthesis engine that is directly controlled by the unanalysed audio signal of the instrument and indirectly by control parameters mapped to the synthesis engine. This method offers a highly string-specific playability, as it is sensitive to the kinds of musical articulation produced by traditional playing techniques. Nuances of sound variation applied by the player will be present in the output signal even if those nuances are beyond traditionally measurable parameters like pitch, amplitude or brightness. The relatively minimal hardware requirements make the instrument accessible with little expenditure.},
   Keywords                 = {Electronic bowed string instrument, playability, musical instrument design, human computer interface, oscillation controlled sound synthesis},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_150.pdf},
   DOI                      = {10.5281/zenodo.1176655}
@@ -476,6 +482,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {100--103},
+  Abstract                 = {Auracle is a "group instrument," controlled by the voice, for real-time, interactive, distributed music making over the Internet. It is implemented in the Java™ programming language using a combination of publicly available libraries (JSyn and TransJam) and custom-built components. This paper describes how the various pieces --- the voice analysis, network communication, and sound synthesis --- are individually built and how they are combined to form Auracle.},
   Keywords                 = {Interactive Music Systems, Networking and Control, Voice and Speech Analysis, Auracle, JSyn, TransJam, Linear Prediction, Neural Networks, Voice Interface, Open Sound Control},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_100.pdf},
   DOI                      = {10.5281/zenodo.1176657}
@@ -488,6 +495,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {108--111},
+  Abstract                 = {We present case studies of unusual instruments that share the same excitation mechanism as that of the bowed string. The musical saw, Tibetan singing bow, glass harmonica, and bowed cymbal all produce sound by rubbing a hard object on the surface of the instrument. For each, we discuss the design of its physical model and present a means for expressively controlling it. Finally, we propose a new kind of generalized friction controller to be used in all these examples.},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_108.pdf},
   DOI                      = {10.5281/zenodo.1176659}
 }
@@ -499,7 +507,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {213--214},
-  Abstract                 = {This paper describes the design and on-going development ofan expressive gestural MIDI interface and how this couldenhance live performance of electronic music.},
+  Abstract                 = {This paper describes the design and on-going development of an expressive gestural MIDI interface and how this couldenhance live performance of electronic music.},
   Keywords                 = {gestural control, mapping, Pure Data (pd), accelerometers, MIDI, microcontrollers, synthesis, musical instruments},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_213.pdf},
   DOI                      = {10.5281/zenodo.1176661}
@@ -512,7 +520,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {51--54},
-  Abstract                 = {In this report, we discuss Tree Music, an interactive computermusic installation created using GAIA (Graphical Audio InterfaceApplication), a new open-source interface for controlling theRTcmix synthesis and effects processing engine. Tree Music,commissioned by the University of Virginia Art Museum, used awireless camera with a wide-angle lens to capture motion andocclusion data from exhibit visitors. We show how GAIA wasused to structure and navigate the compositional space, and howthis program supports both graphical and text-based programmingin the same application. GAIA provides a GUI which combinestwo open-source applications: RTcmix and Perl.},
+  Abstract                 = {In this report, we discuss Tree Music, an interactive computer music installation created using GAIA (Graphical Audio Interface Application), a new open-source interface for controlling the RTcmix synthesis and effects processing engine. Tree Music, commissioned by the University of Virginia Art Museum, used a wireless camera with a wide-angle lens to capture motion and occlusion data from exhibit visitors. We show how GAIA was used to structure and navigate the compositional space, and how this program supports both graphical and text-based programming in the same application. GAIA provides a GUI which combines two open-source applications: RTcmix and Perl.},
   Keywords                 = {Composition, new interfaces, interactive systems, open source, Real time audio, GUI controllers, video tracking},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_051.pdf},
   DOI                      = {10.5281/zenodo.1176663}
@@ -577,6 +585,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {13--18},
+  Abstract                 = {We have developed new sound feedback for powerful karate training with pleasure, which enables to extract player's movement, understand player's activities, and generate them to sounds. We have designed a karate training environment which consists of a multimodal room with cameras, microphones, video displays and loud speakers, and wearable devices with a sensor and a sound generator. Experiments have been conducted on ten Karate beginnners for ten months to examine the effectiveness to learn appropriate body action and sharpness in basic punch called TSUKI. The experimental results suggest the proposed sound feedback and the training environments enable beginners to achieve enjoyable Karate.},
   Keywords                 = {Sound feedback, Karate, Learning environment, Wearable device},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_013.pdf},
   DOI                      = {10.5281/zenodo.1176673}
@@ -614,6 +623,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {116--119},
+  Abstract                 = {The authors have developed several methods for spatially distributing spectral material in real-time using frequency-domain processing. Applying spectral spatialization techniques to more than two channels introduces a few obstacles, particularly with controllers, visualization and the manipulation of large amounts of control data. Various interfaces are presented which address these issues. We also discuss 3D “cube” controllers and visualizations, which go a long way in aiding usability. A range of implementations were realized, each with its own interface, automation, and output characteristics. We also explore a number of novel techniques. For example, a sound’s spectral components can be mapped in space based on its own components’ energy, or the energy of another signal’s components (a kind of spatial cross-synthesis). Finally, we address aesthetic concerns, such as perceptual and sonic coherency, which arise when sounds have been spectrally dissected and scattered across a multi-channel spatial field in 64, 128 or more spectral bands.},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_116.pdf},
   DOI                      = {10.5281/zenodo.1176679}
 }
@@ -651,7 +661,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {209--210},
-  Abstract                 = {In this paper, we describe a new MIDI controller, the LightPipes. The Light Pipes are a series of pipes that respond toincident light. The paper will discuss the design of theinstrument, and the prototype we built. A piece was composedfor the instrument using algorithms designed in Pure Data.},
+  Abstract                 = {In this paper, we describe a new MIDI controller, the Light Pipes. The Light Pipes are a series of pipes that respond to incident light. The paper will discuss the design of the instrument, and the prototype we built. A piece was composed for the instrument using algorithms designed in Pure Data.},
   Keywords                 = {Controllers, MIDI, light sensors, Pure Data.},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_209.pdf},
   DOI                      = {10.5281/zenodo.1176685}
@@ -664,6 +674,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {23--26},
+  Abstract                 = {We present a prototype of a new musical interface for Japanese drumming techniques and styles. Our design used in the Aobachi drumming sticks provides 5 gesture parameters (3 axes of acceleration, and 2 axes of angular velocity) for each of the two sticks and transmits this data wirelessly using Bluetooth® technology. This system utilizes minimal hardware embedded in the two drumming sticks, allowing for gesture tracking of drum strokes by an interface of traditional form, appearance, and feel. Aobachi is portable, versatile, and robust, and may be used for a variety of musical applications, as well as analytical studies.},
   Keywords                 = {bluetooth,drum stick,japanese drum,taiko,wireless},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_023.pdf},
   DOI                      = {10.5281/zenodo.1176687}
@@ -676,7 +687,7 @@ authordiscusses the creation of new controllers based on theshamanic use of ritu
   Year                     = {2004},
   Address                  = {Hamamatsu, Japan},
   Pages                    = {112--115},
-  Abstract                 = {This paper describes ThumbTEC, a novel general purposeinput device for the thumb or finger that is useful in a widevariety of applications from music to text entry. The device i smade up of three switches in a row and one miniature joystickon top of the middle switch. The combination of joystickdirection and switch(es) controls what note or alphanumericcharacter is selected by the finger. Several applications aredetailed.},
+  Abstract                 = {This paper describes ThumbTEC, a novel general purpose input device for the thumb or finger that is useful in a wide variety of applications from music to text entry. The device is made up of three switches in a row and one miniature joystick on top of the middle switch. The combination of joystick direction and switch(es) controls what note or alphanumeric character is selected by the finger. Several applications are detailed.},
   Keywords                 = {One-Thumb Input Device, HCI, Isometric Joystick, Mobile Computing, Handheld Devices, Musical Instrument.},
   Url                      = {http://www.nime.org/proceedings/2004/nime2004_112.pdf},
   DOI                      = {10.5281/zenodo.1176689}


### PR DESCRIPTION
Fixes #18 

- all abstracts now present in `paper_proceedings/nime2004.bib`
- fixed some other abstracts that had missing spaces in text, likely due to cut and paste from PDF
- follows the format of the existing BibTex file