### PR TITLE
Add all abstract and some keyword entries for 2010

### DIFF
--- a/paper_proceedings/nime2010.bib
+++ b/paper_proceedings/nime2010.bib
@@ -18,7 +18,8 @@
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {63--68},
-  Keywords                 = {instant messaging,nime10,sms,sonority,text sonification},
+  Abstract                 = {Writing text messages (e.g. email, SMS, instant messaging) is a popular form of synchronous and asynchronous communication. However, when it comes to notifying users about new messages, current audio-based approaches, such as notification tones, are very limited in conveying information. In this paper we show how entire text messages can be encoded into a meaningful and euphonic melody in such a way that users can guess a message’s intention without actually seeing the content. First, as a proof of concept, we report on the findings of an initial on-line survey among 37 musicians and 32 non-musicians evaluating the feasibility and validity of our approach. We show that our representation is understandable and that there are no significant differences between musicians and non-musicians. Second, we evaluated the approach in a real world scenario based on a Skype plug-in. In a field study with 14 participants we showed that sonified text messages strongly impact on the users’ message checking behavior by significantly reducing the time between receiving and reading an incoming message.},
+  Keywords                 = {instant messaging, sms, sonority, text sonification},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_063.pdf},
   DOI                      = {10.5281/zenodo.1177713}
 }
@@ -134,6 +135,7 @@
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {170--173},
+  Abstract                 = {Virginia Tech Department of Music’s Digital Interactive Sound & Intermedia Studio in collaboration with the College of Engineering and School of Visual Arts presents the latest addition to the *Ork family, the Linux Laptop Orchestra. Apart from maintaining compatibility with its precursors and sources of inspiration, Princeton’s PLOrk, and Stanford’s SLOrk, L2Ork’s particular focus is on delivering unprecedented affordability without sacrificing quality, as well as flexibility necessary to encourage a more widespread adoption and standardization of the laptop orchestra ensemble. The newfound strengths of L2Ork’s design have resulted in opportunities in K-12 education with a particular focus on cross-pollinating STEM and Arts, as well as research of an innovative content delivery system that can seamlessly engage students regardless of their educational background. In this document we discuss key components of the L2Ork initiative, their benefits, and offer resources necessary for the creation of other Linux-based *Orks},
   Keywords                 = {l2ork,laptop orchestra,linux,nime10},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_170.pdf},
   DOI                      = {10.5281/zenodo.1177731}
@@ -146,9 +148,7 @@
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {493--496},
-  Abstract                 = {This paper describes a series of mathematical functions implemented by the ,
-,
-author in the commercial algorithmic software language ArtWonk, written by John Dunn, which are offered with that language as resources for composers. It gives a history of the development of the functions, with an emphasis on how I developed them for use in my compositions. },
+  Abstract                 = {This paper describes a series of mathematical functions implemented by the author in the commercial algorithmic software language ArtWonk, written by John Dunn, which are offered with that language as resources for composers. It gives a history of the development of the functions, with an emphasis on how I developed them for use in my compositions.},
   Keywords                 = {Algorithmic composition, mathematical composition, probability distributions, fractals, additive sequences},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_493.pdf},
   DOI                      = {10.5281/zenodo.1177733}
@@ -161,7 +161,8 @@ author in the commercial algorithmic software language ArtWonk, written by John 
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {120--124},
-  Keywords                 = {augmented instruments,expressive spatial,nime10,playable instruments},
+  Abstract                 = {This paper presents research undertaken by the Bent Leather Band investigating the application of live Ambisonics to large digital-instrument ensemble improvisation. Their playable approach to live ambisonic projection is inspired by the work of Trevor Wishart and presents a systematic investigation of the potential for live spatial motion improvisation.},
+  Keywords                 = {ambisonics, augmented instruments, expressive spatial motion, playable instruments},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_120.pdf},
   DOI                      = {10.5281/zenodo.1177735}
 }
@@ -173,7 +174,7 @@ author in the commercial algorithmic software language ArtWonk, written by John 
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {229--232},
-  Abstract                 = {This paper presents a virtual violin for real-time performances consisting of two modules: a violin spectral modeland a control interface. The interface is composed by asensing bow and a tube with drawn strings in substitutionof a real violin. The spectral model is driven by the bowingcontrols captured with the control interface and it is ableto predict spectral envelopes of the sound corresponding tothose controls. The envelopes are filled with harmonic andnoisy content and given to an additive synthesizer in orderto produce violin sounds. The sensing system is based ontwo motion trackers with 6 degrees of freedom. One trackeris attached to the bow and the other to the tube. Bowingcontrols are computed after a calibration process where theposition of virtual strings and the hair-ribbon of the bowis obtained. A real time implementation was developed asa MAX/MSP patch with external objects for each of themodules.},
+  Abstract                 = {This paper presents a virtual violin for real-time performances consisting of two modules: a violin spectral model and a control interface. The interface is composed by a sensing bow and a tube with drawn strings in substitution of a real violin. The spectral model is driven by the bowing controls captured with the control interface and it is able to predict spectral envelopes of the sound corresponding to those controls. The envelopes are filled with harmonic andnoisy content and given to an additive synthesizer in order to produce violin sounds. The sensing system is based on two motion trackers with 6 degrees of freedom. One tracker is attached to the bow and the other to the tube. Bowing controls are computed after a calibration process where the position of virtual strings and the hair-ribbon of the bowis obtained. A real time implementation was developed asa MAX/MSP patch with external objects for each of the modules.},
   Keywords                 = {violin, synthesis, control, spectral, virtual},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_229.pdf},
   DOI                      = {10.5281/zenodo.1177737}
@@ -238,6 +239,7 @@ author in the commercial algorithmic software language ArtWonk, written by John 
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {125--129},
+  Abstract                 = {The hypothesis of this interaction research project is that it can be stimulating for experimental musicians to confront a system which ‘opposes’ their musical style. The ‘contrary motion’ of the title is the name of a MIDI-based realtime musical software agent which uses machine listening to establish the musical context, and thereby chooses its own responses to differentiate its position from that of its human interlocutant. To do this requires a deep consideration of the space of musical actions, so as to explicate what opposition should constitute, and machine listening technology (most prominently represented by new online beat and stream tracking algorithms) which gives an accurate measurement of player position so as to consistently avoid it. An initial pilot evaluation was undertaken, feeding back critical data to the developing design.},
   Keywords                 = {contrary, beat tracking, stream analysis, musical agent},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_125.pdf},
   DOI                      = {10.5281/zenodo.1177747}
@@ -251,7 +253,7 @@ author in the commercial algorithmic software language ArtWonk, written by John 
   Address                  = {Sydney, Australia},
   Pages                    = {455--458},
   Abstract                 = {Gaining access to a prototype motion capture suit designedby the Animazoo company, the Interactive Systems groupat the University of Sussex have been investigating application areas. This paper describes our initial experimentsin mapping the suit control data to sonic attributes for musical purposes. Given the lab conditions under which weworked, an agile design cycle methodology was employed,with live coding of audio software incorporating fast feedback, and more reflective preparations between sessions, exploiting both individual and pair programming. As the suitprovides up to 66 channels of information, we confront achallenging mapping problem, and techniques are describedfor automatic calibration, and the use of echo state networksfor dimensionality reduction.},
-  Keywords                 = {Motion Capture, Musical Controller, Mapping, Agile De- sign},
+  Keywords                 = {Motion Capture, Musical Controller, Mapping, Agile Design},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_455.pdf},
   DOI                      = {10.5281/zenodo.1177749}
 }
@@ -302,7 +304,8 @@ author in the commercial algorithmic software language ArtWonk, written by John 
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {467--468},
-  Keywords                 = {nime10},
+  Abstract                 = {P[a]ra[pra]xis is an ongoing collaborative project incorporating a two-piece software package which explores human relations to language through dynamic sound and text production. Incorporating an exploration of the potential functions and limitations of the ‘sign’ and the intrusions of the Unconscious into the linguistic utterance via parapraxes, or ‘Freudian slips’, our software utilises realtime subject response to automatically- generated changes in a narrative of their own writing to create music. This paper considers the relative paucity of truly interactive realtime text and audio works and provides an account of current and future potential for the simultaneous production of realtime poetry and electronic music through the P[a]ra[pra]xis software. It also provides the basis for a demonstration session in which we hope to show users how the program works, discuss possibilities for different applications of the software, and collect data for future collaborative work.},
+  Keywords                 = {language sonification, new media poetry, realtime, Lacan, semiotics, collaborative environment, psychoanalysis, Freud},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_467.pdf},
   DOI                      = {10.5281/zenodo.117777}
 }
@@ -393,7 +396,7 @@ author in the commercial algorithmic software language ArtWonk, written by John 
   Address                  = {Sydney, Australia},
   Pages                    = {473--476},
   Abstract                 = {This paper presents the development of rapid and reusablegestural interface prototypes for navigation by similarity inan audio database and for sound manipulation, using theAudioCycle application. For this purpose, we propose andfollow guidelines for rapid prototyping that we apply usingthe PureData visual programming environment. We havemainly developed three prototypes of manual control: onecombining a 3D mouse and a jog wheel, a second featuring a force-feedback 3D mouse, and a third taking advantage of the multitouch trackpad. We discuss benefits andshortcomings we experienced while prototyping using thisapproach.},
-  Keywords                 = {Human-computer interaction, gestural interfaces, rapid pro- totyping, browsing by similarity, audio database},
+  Keywords                 = {Human-computer interaction, gestural interfaces, rapid prototyping, browsing by similarity, audio database},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_473.pdf},
   DOI                      = {10.5281/zenodo.1177771}
 }
@@ -522,6 +525,7 @@ author in the commercial algorithmic software language ArtWonk, written by John 
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {335--338},
+  Abstract                 = {Awareness of playing movements can help a piano student to improve technique. We are developing a piano pedagogy application that uses sensor data of hand and arm movement and generates feedback to increase movement awareness. This paper reports on a method for analysis of piano playing movements. The method allows to judge whether an active movement in a joint has occurred during a given time interval. This time interval may include one or more touches. The problem is complicated by the fact that the mechanical interaction between the arm and piano action generates additional movements that are not under direct control of the player. The analysis method is able to ignore these movements and can therefore be used to provide useful feedback.},
   Keywords                 = {nime10},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_335.pdf},
   DOI                      = {10.5281/zenodo.1177791}
@@ -534,9 +538,7 @@ author in the commercial algorithmic software language ArtWonk, written by John 
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {489--492},
-  Abstract                 = {In his demonstration, the ,
-,
-author discusses the sequential progress of his technical and aesthetic decisions as composer and videographer for four large-scale works for dance through annotated video examples of live performances and PowerPoint slides. In addition, he discusses his current real-time dance work with wireless sensor interfaces using sewable LilyPad Arduino modules and Xbee radio hardware. Keywords },
+  Abstract                 = {In his demonstration, the author discusses the sequential progress of his technical and aesthetic decisions as composer and videographer for four large-scale works for dance through annotated video examples of live performances and PowerPoint slides. In addition, he discusses his current real-time dance work with wireless sensor interfaces using sewable LilyPad Arduino modules and Xbee radio hardware.},
   Keywords                 = {dance, video processing, video tracking, LilyPad Arduino.},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_489.pdf},
   DOI                      = {10.5281/zenodo.1177793}
@@ -550,7 +552,7 @@ author discusses the sequential progress of his technical and aesthetic decision
   Address                  = {Sydney, Australia},
   Pages                    = {94--99},
   Abstract                 = {This paper describes a novel method for composing andimprovisation with real-time chaotic oscillators. Recentlydiscovered algebraically simple nonlinear third-order differential equations are solved and acoustical descriptors relating to their frequency spectrums are determined accordingto the MPEG-7 specification. A second nonlinearity is thenadded to these equations: a real-time audio signal. Descriptive properties of the complex behaviour of these equationsare then determined as a function of difference tones derived from a Just Intonation scale and the amplitude ofthe audio signal. By using only the real-time audio signalfrom live performer/s as an input the causal relationshipbetween acoustic performance gestures and computer output, including any visual or performer-instruction output,is deterministic even if the chaotic behaviours are not.},
-  Keywords                 = {audio de-,chaos and music,chaotic dynamics and oscillators,dif-,ferential equations and music,mathematica,nime10,scriptors and mpeg-7},
+  Keywords                 = {chaos and music, chaotic dynamics and oscillators, differential equations and music, mathematica, audio descriptors and mpeg-7},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_094.pdf},
   DOI                      = {10.5281/zenodo.1177795}
 }
@@ -562,6 +564,7 @@ author discusses the sequential progress of his technical and aesthetic decision
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {100--105},
+  Abstract                 = {Traditional drum machines and digital drum-kits offer users the ability to practice or perform with a supporting ensemble – such as a bass, guitar and piano – but rarely provide support in the form of an accompanying percussion part. Beatback is a system which develops upon this missing interaction through offering a MIDI enabled drum system which learns and plays in the user's style. In the contexts of rhythmic practise and exploration, Beatback looks at call-response and accompaniment models of interaction to enable new possibilities for rhythmic creativity.},
   Keywords                 = {Interactive music interface, real-time, percussion, machine learning, Markov models, MIDI.},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_100.pdf},
   DOI                      = {10.5281/zenodo.1177797}
@@ -575,7 +578,7 @@ author discusses the sequential progress of his technical and aesthetic decision
   Address                  = {Sydney, Australia},
   Pages                    = {23--25},
   Abstract                 = {The Neurohedron is a multi-modal interface for a nonlinear sequencer software model, embodied physically in a dodecahedron. The faces of the dodecahedron are both inputs and outputs, allowing the device to visualize the activity of the software model as well as convey input to it. The software model maps MIDI notes to the faces of the device, and defines and controls the behavior of the sequencer's progression around its surface, resulting in a unique instrument for computer-based performance and composition. },
-  Keywords                 = {controller,human computer interaction,interface,live performance,neural network,nime10,sequencer},
+  Keywords                 = {controller, human computer interaction, interface, live performance, neural network, sequencer},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_023.pdf},
   DOI                      = {10.5281/zenodo.1177799}
 }
@@ -588,7 +591,7 @@ author discusses the sequential progress of his technical and aesthetic decision
   Address                  = {Sydney, Australia},
   Pages                    = {423--426},
   Abstract                 = {In this paper, we present an interactive system that uses the body as a generative tool for creating music. We explore innovative ways to make music, create self-awareness, and provide the opportunity for unique, interactive social experiences. The system uses a multi-player game paradigm, where players work together to add layers to a soundscape of three distinct environments. Various sensors and hardware are attached to the body and transmit signals to a workstation, where they are processed using Max/MSP. The game is divided into three levels, each of a different soundscape. The underlying purpose of our system is to move the player's focus away from complexities of the modern urban world toward a more internalized meditative state. The system is currently viewed as an interactive installation piece, but future iterations have potential applications in music therapy, bio games, extended performance art, and as a prototype for new interfaces for musical expression. },
-  Keywords                 = {biomusic,collaborative,expressive,hci,interactive,interactivity design,interface for musical expression,multimodal,musical mapping strategies,nime10,performance,sonification},
+  Keywords                 = {biomusic, collaborative, expressive, hci, interactive, interactivity design, interface for musical expression, multimodal, musical mapping strategies,nime10,performance,sonification},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_423.pdf},
   DOI                      = {10.5281/zenodo.1177801}
 }
@@ -704,6 +707,7 @@ author discusses the sequential progress of his technical and aesthetic decision
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {352--355},
+  Abstract                 = {The project H\'{e}(和, harmony) is a sound installation that enables a user to play music by writing calligraphy. We developed a system where calligraphic symbols can be detected and converted to a sound composed of pitch, pitch length, and volume though MIDI and serial communication. The H\'{e} sound installation involves a micro-controller, photocells, and multiplexers. A DC motor controls the speed of a spooled paper roll that is capable of setting the music tempo. This paper presents the design concept and implementation of H\'{e}. We discuss the major research issues such as using photocells for detecting components of calligraphy like thickness and location. Hardware and software details are also discussed. Finally, we explore the potential for further extending musical and visual experience through this project’s applications and outcomes.},
   Keywords                 = {Interactive music interface, calligraphy, graphical music composing, sonification},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_352.pdf},
   DOI                      = {10.5281/zenodo.1177819}
@@ -742,6 +746,7 @@ author discusses the sequential progress of his technical and aesthetic decision
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {444--446},
+  Abstract                 = {In this paper, we present and demonstrate Samsung’s new concept music creation engine and music composer application for mobile devices such as touch phones or MP3 players, ‘Interactive Music Studio : the soloist’.},
   Keywords                 = {Mobile device, music composer, pattern composing, MIDI},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_444.pdf},
   DOI                      = {10.5281/zenodo.1177825}
@@ -782,7 +787,7 @@ author discusses the sequential progress of his technical and aesthetic decision
   Pages                    = {309--314},
   Abstract                 = {Most new digital musical interfaces have evolved upon theintuitive idea that there is a causality between sonic outputand physical actions. Nevertheless, the advent of braincomputer interfaces (BCI) now allows us to directly accesssubjective mental states and express these in the physicalworld without bodily actions. In the context of an interactive and collaborative live performance, we propose to exploit novel brain-computer technologies to achieve unmediated brain control over music generation and expression.We introduce a general framework for the generation, synchronization and modulation of musical material from brainsignal and describe its use in the realization of Xmotion, amultimodal performance for a "brain quartet".},
   Date-modified            = {2013-06-06 20:01:54 +0000},
-  Keywords                 = {Brain-computer Interface, Biosignals, Interactive Music Sys- tem, Collaborative Musical Performance},
+  Keywords                 = {Brain-computer Interface, Biosignals, Interactive Music System, Collaborative Musical Performance},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_309.pdf},
   DOI                      = {10.5281/zenodo.1177831}
 }
@@ -794,7 +799,8 @@ author discusses the sequential progress of his technical and aesthetic decision
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {51--56},
-  Keywords                 = {audio,control surfaces,mixing board,multitouch,nime10,screen,sound,theatre,touch-,user-centered design},
+  Abstract                 = {We present Cuebert, a mixing board concept for musical theatre. Using a user-centered design process, our goal was to reconceptualize the mixer using modern technology and interaction techniques, questioning over fifty years of interface design in audio technology. Our research resulted in a design that retains the physical controls — faders and knobs — demanded by sound engineers while taking advantage of multitouch display technology to allow for flexible display of dynamic and context-sensitive content.},
+  Keywords                 = {audio, control surfaces, mixing board, multitouch, sound, theatre, touch-screen, user-centered design},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_051.pdf},
   DOI                      = {10.5281/zenodo.1177833}
 }
@@ -807,7 +813,7 @@ author discusses the sequential progress of his technical and aesthetic decision
   Address                  = {Sydney, Australia},
   Pages                    = {477--478},
   Abstract                 = {In this paper we present a novel system for tactile actuation in stylus-based musical interactions. The proposed controller aims to support rhythmical musical performance. The system builds on resistive force feedback, which is achieved through a brakeaugmented ball pen stylus on a sticky touch-sensitive surface. Along the device itself, we present musical interaction principles that are enabled through the aforementioned tactile response. Further variations of the device and perspectives of the friction-based feedback are outlined. },
-  Keywords                 = {force feedback,haptic feedback,interactive,nime10,pen controller},
+  Keywords                 = {force feedback, haptic feedback, interactive, pen controller},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_477.pdf},
   DOI                      = {10.5281/zenodo.1177835}
 }
@@ -871,6 +877,7 @@ author discusses the sequential progress of his technical and aesthetic decision
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {7--12},
+  Abstract                 = {Musical instruments have a long history, and many types of musical instruments have been created to attain ideal sound production. At the same time, various types of electronic musical instruments have been developed. Since the main purpose of conventional electronic instruments is to duplicate the shape of acoustic instruments with no change in their hardware configuration, the diapason and the performance style of each instrument is inflexible. Therefore, the goal of our study is to construct the UnitInstrument that consists of various types of musical units. A unit is constructed by simulating functional elements of conventional musical instruments, such as output timing of sound and pitch decision. Each unit has connectors for connecting other units to create various types of musical instruments. Additionally, we propose a language for easily and flexibly describing the settings of units. We evaluated the effectiveness of our proposed system by using it in actual performances.},
   Keywords                 = {Musical instruments, Script language},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_007.pdf},
   DOI                      = {10.5281/zenodo.1177845}
@@ -883,6 +890,7 @@ author discusses the sequential progress of his technical and aesthetic decision
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {479--480},
+  Abstract                 = {The American experimental tradition in music emphasizes a process-oriented – rather than goal-oriented – composition style. According to this tradition, the composition process is considered an experiment beginning with a problem resolved by the composer. The noted experimental composer John Cage believed that the artist’s role in composition should be one of coexistence, as opposed to the traditional view of directly controlling the process. Consequently, Cage devel- oped methods of composing that upheld this philosophy by utilizing musical charts and the I Ching, also known as the Chinese Book of Changes. This project investigates these methods and models them via an interactive computer system to explore the use of modern interfaces in experimental composition.},
   Keywords                 = {Multi-touch Interfaces, Computer-Assisted Composition},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_479.pdf},
   DOI                      = {10.5281/zenodo.1177847}
@@ -908,7 +916,8 @@ author discusses the sequential progress of his technical and aesthetic decision
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {501--504},
-  Keywords                 = {algorithmic composition,nime10,soft constraints,tangible interaction},
+  Abstract                 = {‘The Planets’ combines a novel approach for algorithmic composition with new human-computer interaction paradigms and realistic painting techniques. The main inspiration for it was the composition ‘The Planets’ from Gustav Holst who portrayed each planet in our solar system with music. Our application allows to interactively compose music in real-time by arranging planet constellations on an interactive table. The music generation is controlled by painted miniatures of the planets and the sun which are detected by the table and supplemented with an additional graphical visualization, creating a unique audio-visual experience. A video of the application can be found in [1].},
+  Keywords                 = {algorithmic composition, soft constraints, tangible interaction},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_501.pdf},
   DOI                      = {10.5281/zenodo.1177851}
 }
@@ -946,10 +955,8 @@ author discusses the sequential progress of his technical and aesthetic decision
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {186--191},
-  Abstract                 = {The evolution of networked audio technologies has created unprecedented opportunities for musicians to improvise with instrumentalists from a diverse range of cultures and disciplines. As network speeds increase and latency is consigned to history, tele-musical collaboration, and in particular improvisation will be shaped by new methodologies that respond to this potential. While networked technologies eliminate distance in physical space, for the remote improviser, this creates a liminality of experience through which their performance is mediated. As a first step in understanding the conditions arising from collaboration in networked audio platforms, this paper will examine selected case studies of improvisation in a variety of networked interfaces. The ,
-,
-author will examine how platform characteristics and network conditions influence the process of collective improvisation and the methodologies musicians are employing to negotiate their networked experiences. },
-  Keywords                 = {improvisation,internet audio,networked collaboration,nime10,sound},
+  Abstract                 = {The evolution of networked audio technologies has created unprecedented opportunities for musicians to improvise with instrumentalists from a diverse range of cultures and disciplines. As network speeds increase and latency is consigned to history, tele-musical collaboration, and in particular improvisation will be shaped by new methodologies that respond to this potential. While networked technologies eliminate distance in physical space, for the remote improviser, this creates a liminality of experience through which their performance is mediated. As a first step in understanding the conditions arising from collaboration in networked audio platforms, this paper will examine selected case studies of improvisation in a variety of networked interfaces. The author will examine how platform characteristics and network conditions influence the process of collective improvisation and the methodologies musicians are employing to negotiate their networked experiences.},
+  Keywords                 = {improvisation, internet audio, networked collaboration, sound art},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_186.pdf},
   DOI                      = {10.5281/zenodo.1177857}
 }
@@ -974,7 +981,8 @@ author will examine how platform characteristics and network conditions influenc
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {13--18},
-  Keywords                 = {amplification,modal perception,multi,musical instruments,nime10,performance practice,sound technology},
+  Abstract                 = {With the author’s own experiences in mind, this paper argues that, when used to amplify musical instruments or to play back other sonic material to an audience, loudspeakers and the technology that drives them, can be considered as a musical instrument. Particularly in situations with acoustic instruments this perspective can provide insight into the often cumbersome relation between the –technology orientated– sound engineer and the –music orientated– performer. Playing a musical instrument (whether acoustic, electric or electronic) involves navigating often complicated but very precise interfaces. The interface for sound amplification technology in a certain environment is not limited to the control surface of a mixing desk but includes the interaction with other stakeholder, i.e. the performers and the choice of loudspeakers and microphones and their positions. As such this interface can be as accurate and intimate but also as complicated as the interfaces of 'normal' musical instruments. By zooming in on differences between acoustic and electronic sources a step is taken towards inclusion in this discussion of the perception of amplified music and the possible influence of that amplification on performance practise.},
+  Keywords                 = {Sound technology (amplification), musical instruments, multi modal perception, performance practice.},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_013.pdf},
   DOI                      = {10.5281/zenodo.1177861}
 }
@@ -1025,6 +1033,7 @@ author will examine how platform characteristics and network conditions influenc
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {259--262},
+  Abstract                 = {In this paper we present a method for studying relationships between features of sound and features of movement. The method has been tested by carrying out an experiment with people moving an object in space along with short sounds. 3D position data of the object was recorded and several features were calculated from each of the recordings. These features were provided as input to a classifier which was able to classify the recorded actions satisfactorily, particularly when taking into account that the only link between the actions performed by the different subjects was the sound they heard while making the action.},
   Keywords                 = {nime10},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_259.pdf},
   DOI                      = {10.5281/zenodo.1177869}
@@ -1089,6 +1098,7 @@ author will examine how platform characteristics and network conditions influenc
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {212--216},
+  Abstract                 = {Glitch DeLighter is a HyperInstrument conceived for Glitch music, based on the idea of using fire expressiveness to digitally distort sound, pushing the body and primitive ritualism into a computer mediated sound performance. Glitch DeLighter uses ordinary lighters as physical controllers that can be played by creating a flame and moving it in the air. Droned sounds are played by sustaining the flame and beats by generating sparks and fast flames. The pitch of every sound can be changed moving the flame vertically in the air. This is achieved by using a custom computer vision system as an interface which maps the real-time the data extracted from the flame and transmits those parameters to the sound generator. As a result, the flame visual dynamics are deeply connected to the aural perception of the sound - ‘the sound seems to be burning’. This process establishes a metaphor dramaturgically engaging for an audience. This paper contextualizes the glitch music aesthetics, prior research, the design and development of the instrument and reports on Burning The Sound– the first music composition created and performed with the instrument (by the author).},
   Keywords                 = {Hyper-Instruments, Glitch Music, Interactive Systems, Electronic Music Performance.},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_212.pdf},
   DOI                      = {10.5281/zenodo.1177879}
@@ -1114,7 +1124,8 @@ author will examine how platform characteristics and network conditions influenc
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {57--62},
-  Keywords                 = {AlloSphere, mapping, performance, HCI, interactivity, Vir- tual Reality, OSC, multi-user, network},
+  Abstract                 = {We present the Device Server, a framework and application driving interaction in the AlloSphere virtual reality environment. The motivation and development of the Device Server stems from the practical concerns of managing multi-user interactivity with a variety of physical devices for disparate performance and virtual reality environments housed in the same physical location. The interface of the Device Server allows users to see how devices are assigned to application functionalities, alter these assignments and save them into configuration files for later use. Configurations defining how applications use devices can be changed on the fly without recompiling or relaunching applications. Multiple applications can be connected to the Device Server concurrently. The Device Server provides several conveniences for performance environments. It can process control data efficiently using Just-In-Time compiled Lua expressions; in doing so it frees processing cycles on audio and video rendering computers. All control signals entering the Device Server can be recorded, saved, and played back allowing performances based on control data to be recreated in their entirety. The Device Server attempts to homogenize the appearance of different control signals to applications so that users can assign any interface element they choose to application functionalities and easily experiment with different control configurations.},
+  Keywords                 = {AlloSphere, mapping, performance, HCI, interactivity, Virtual Reality, OSC, multi-user, network},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_057.pdf},
   DOI                      = {10.5281/zenodo.1177883}
 }
@@ -1127,7 +1138,7 @@ author will examine how platform characteristics and network conditions influenc
   Address                  = {Sydney, Australia},
   Pages                    = {431--435},
   Abstract                 = {The Ghost has been developed to create a merger between the standard MIDI keyboard controller, MIDI/digital guitars and alternative desktop controllers. Using a custom software editor, The Ghost's controls can be mapped to suit the users performative needs. The interface takes its interaction and gestural cues from the guitar but it is not a MIDI guitar. The Ghost's hardware, firmware and software will be open sourced with the hopes of creating a community of users that are invested in creating music with controller.},
-  Keywords                 = {Controller, MIDI, Live Performance, Programmable, Open- Source},
+  Keywords                 = {Controller, MIDI, Live Performance, Programmable, Open-Source},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_431.pdf},
   DOI                      = {10.5281/zenodo.1177885}
 }
@@ -1166,7 +1177,7 @@ author will examine how platform characteristics and network conditions influenc
   Address                  = {Sydney, Australia},
   Pages                    = {136--139},
   Abstract                 = {Multi-point devices are rapidly becoming a practical interface choice for electronic musicians. Interfaces that generate multiple simultaneous streams of point data present a unique mapping challenge. This paper describes an analysis system for point relationships that acts as a bridge between raw streams of multi-point data and the instruments they control, using a multipoint trackpad to test various configurations. The aim is to provide a practical approach for instrument programmers working with multi-point tools, while highlighting the difference between mapping systems based on point coordinate streams, grid evaluations, or object interaction and mapping systems based on multi-point data relationships. },
-  Keywords                 = {Multi-point, multi-touch interface, instrument mapping, multi- point data analysis, trackpad instrument},
+  Keywords                 = {Multi-point, multi-touch interface, instrument mapping, multi-point data analysis, trackpad instrument},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_136.pdf},
   DOI                      = {10.5281/zenodo.1177891}
 }
@@ -1179,7 +1190,7 @@ author will examine how platform characteristics and network conditions influenc
   Address                  = {Sydney, Australia},
   Pages                    = {244--249},
   Abstract                 = {The design of an unusually simple fabric-based touchlocation and pressure sensor is introduced. An analysisof the raw sensor data is shown to have significant nonlinearities and non-uniform noise. Using support vectormachine learning and a state-dependent adaptive filter itis demonstrated that these problems can be overcome.The method is evaluated quantitatively using a statisticalestimate of the instantaneous rate of information transfer.The SVM regression alone is shown to improve the gesturesignal information rate by up to 20% with zero addedlatency, and in combination with filtering by 40% subjectto a constant latency bound of 10 milliseconds.},
-  Keywords                 = {gesture signal processing,nime10,support vector,touch sensor},
+  Keywords                 = {gesture signal processing, support vector machine, touch sensor},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_244.pdf},
   DOI                      = {10.5281/zenodo.1177893}
 }
@@ -1191,6 +1202,7 @@ author will examine how platform characteristics and network conditions influenc
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {407--410},
+  Abstract                 = {The paper presents a conceptual overview of how optical infrared marker based motion capture systems (IrMoCap) can be used in musical interaction. First we present a review of related work of using IrMoCap for musical control. This is followed by a discussion of possible features which can be exploited. Finally, the question of mapping movement features to sound features is presented and discussed.},
   Keywords                 = {nime10},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_407.pdf},
   DOI                      = {10.5281/zenodo.1177895}
@@ -1242,9 +1254,7 @@ author will examine how platform characteristics and network conditions influenc
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {88--93},
-  Abstract                 = {This paper reviews and extends questions of the scope of an interactive musical instrument and mapping strategies for expressive performance. We apply notions of embodiment and affordance to characterize gestural instruments. We note that the democratization of sensor technology in consumer devices has extended the cultural contexts for interaction. We revisit questions of mapping drawing upon the theory of affordances to consider mapping and instrument together. This is applied to recent work by the ,
-,
-author and his collaborators in the development of instruments based on mobile devices designed for specific performance situations. },
+  Abstract                 = {This paper reviews and extends questions of the scope of an interactive musical instrument and mapping strategies for expressive performance. We apply notions of embodiment and affordance to characterize gestural instruments. We note that the democratization of sensor technology in consumer devices has extended the cultural contexts for interaction. We revisit questions of mapping drawing upon the theory of affordances to consider mapping and instrument together. This is applied to recent work by the author and his collaborators in the development of instruments based on mobile devices designed for specific performance situations.},
   Keywords                 = {Musical affordance, NIME, mapping, instrument definition, mobile, multimodal interaction.},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_088.pdf},
   DOI                      = {10.5281/zenodo.1177903}
@@ -1258,7 +1268,7 @@ author and his collaborators in the development of instruments based on mobile d
   Address                  = {Sydney, Australia},
   Pages                    = {88--93},
   Abstract                 = {humanaquarium is a self-contained, transportable performance environment that is used to stage technology-mediated interactive performances in public spaces. Drawing upon the creative practices of busking and street performance, humanaquarium incorporates live musicians, real-time audiovisual content generation, and frustrated total internal reflection (FTIR) technology to facilitate participatory interaction by members of the public. },
-  Keywords                 = {busking,collaborative interface,creative practice,experience centered design,frustrated total internal reflection,ftir,multi-touch screen,multimedia,nime10,participatory performance},
+  Keywords                 = {busking, collaborative interface, creative practice, experience centered design, frustrated total internal reflection (FTIR), multi-touch screen, multimedia, participatory performance},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_440.pdf},
   DOI                      = {10.5281/zenodo.1177905}
 }
@@ -1309,7 +1319,8 @@ author and his collaborators in the development of instruments based on mobile d
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {447--450},
-  Keywords                 = {1,audio mosaic,context --- the sandboxes,corpus-based concatenative synthesis,haptic interface,laptop improvisation,multi-dimensional mapping,nime10},
+  Abstract                 = {In this paper, the authors describe how they use an electric bass as a subtle, expressive and intuitive interface to browse the rich sample bank available to most laptop owners. This is achieved by audio mosaicing of the live bass performance audio, through corpus-based concatenative synthesis (CBCS) techniques, allowing a mapping of the multi-dimensional expressivity of the performance onto foreign audio material, thus recycling the virtuosity acquired on the electric instrument with a trivial learning curve. This design hypothesis is contextualised and assessed within the Sandbox#n series of bass+laptop meta-instruments, and the authors describe technical means of the implementation through the use of the open-source CataRT CBCS system adapted for live mosaicing. They also discuss their encouraging early results and provide a list of further explorations to be made with that rich new interface.},
+  Keywords                 = {laptop improvisation, corpus-based concatenative synthesis, haptic interface, multi-dimensional mapping, audio mosaic},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_447.pdf},
   DOI                      = {10.5281/zenodo.1177913}
 }
@@ -1360,6 +1371,7 @@ author and his collaborators in the development of instruments based on mobile d
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {348--351},
+  Abstract                 = {In this paper we describe work in progress on generative music generation on multi-touch devices. Our goal is to create a musical application framework for multiple casual users that use state of the art multitouch devices. We choose the metaphor of ants moving on a hexagonal grid to interact with a pitch pattern. The set of devices used includes a custom built multitouch table and a number of iPhones to jointly create musical expressions.},
   Keywords                 = {Generative music, mobile interfaces, multitouch interaction},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_348.pdf},
   DOI                      = {10.5281/zenodo.1177921}
@@ -1411,7 +1423,8 @@ author and his collaborators in the development of instruments based on mobile d
   Year                     = {2010},
   Address                  = {Sydney, Australia},
   Pages                    = {150--155},
-  Keywords                 = {turntable, dial, encoder, re-purposed, hard drive, scratch- ing, inherent dynamics, DIY},
+  Abstract                 = {Disky is a computer hard drive re-purposed into a do-it-yourself USB turntable controller that offers high resolution and low latency for controlling parameters of multimedia performance software. Disky is a response to the challenge “re-purpose something that is often discarded and share it with the do-it-yourself community to promote reuse!”},
+  Keywords                 = {turntable, dial, encoder, re-purposed, hard drive, scratch-ing, inherent dynamics, DIY},
   Url                      = {http://www.nime.org/proceedings/2010/nime2010_150.pdf},
   DOI                      = {10.5281/zenodo.1177929}
 }


### PR DESCRIPTION
- 111 articles in total
- 111 abstract entries (missing entries added)
- 111 keywords entries present, with several corrupted keyword lists fixed.
- Articles which did not offer keywords have `nime10` listed as a keyword
- removed multiple instances of "nime10" where paper had keywords
- 17 "nime10" instances still remain. Some of these are papers with no keywords.