### PR TITLE
Wrong order of authors

### DIFF
--- a/paper_proceedings/nime2020.bib
+++ b/paper_proceedings/nime2020.bib
@@ -758,7 +758,7 @@
 }
 
 @inproceedings{NIME20_3,
-  author = {Troiano, Giovanni M and Boem, Alberto and Lepri, Giacomo and Zappi, Victor},
+  author = {Boem, Alberto and Troiano, Giovanni M and and Lepri, Giacomo and Zappi, Victor},
   title = {Non-Rigid Musical Interfaces: Exploring Practices, Takes, and Future Perspective},
   pages = {17--22},
   booktitle = {Proceedings of the International Conference on New Interfaces for Musical Expression},


### PR DESCRIPTION
This refers to the paper 

Giovanni M Troiano, Alberto Boem, Giacomo Lepri, and Victor Zappi. 2020. Non-Rigid Musical Interfaces: Exploring Practices, Takes, and Future Perspective. Proceedings of the International Conference on New Interfaces for Musical Expression, Birmingham City University, pp. 17–22.

The bib file seems based on the order of authors registered at the time of submission...
However, if you can see from the [pdf](https://www.nime.org/proceedings/2020/nime2020_paper3.pdf) of the paper the order of the authors is slightly different, which is the final one.

Sorry for the inconvenience!