### PR TITLE
Add missing abstracts and keywords for 2005

### DIFF
--- a/paper_proceedings/nime2005.bib
+++ b/paper_proceedings/nime2005.bib
@@ -44,7 +44,8 @@
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176713},
   url = {http://www.nime.org/proceedings/2005/nime2005_005.pdf},
-  keywords = {Infra-instruments, hyperinstruments, meta-instruments, virtual instruments, design concepts and principles. }
+  keywords = {Infra-instruments, hyperinstruments, meta-instruments, virtual instruments, design concepts and principles. },
+  abstract = {As a response to a number of notable contemporary aesthetic tendencies, this paper introduces the notion of an infra-instrument as a kind of ‘new interface for musical expression’ worthy of study and systematic design. In contrast to hyper-, meta- and virtual instruments, we propose infra-instruments as devices of restricted interactive potential, with little sensor enhancement, which engender simple musics with scarce opportunity for conventional virtuosity. After presenting numerous examples from our work, we argue that it is precisely such interactionally and sonically challenged designs that leave requisite space for computer-generated augmentations in hybrid, multi-device performance settings.}
 }
 
 @inproceedings{Maki-patola2005,
@@ -57,6 +58,7 @@
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176780},
   url = {http://www.nime.org/proceedings/2005/nime2005_011.pdf},
+  keywords = {Musical instrument design, virtual instrument, gesture, widgets, physical sound modeling, control mapping.},
   abstract = {In this paper, we introduce and analyze four gesture-controlled musical instruments. We briefly discuss the test platform designed to allow for rapid experimentation of new interfaces and control mappings. We describe our design experiences and discuss the effects of system features such as latency, resolution and lack of tactile feedback. The instruments use virtual reality hardware and computer vision for user input, and three-dimensional stereo vision as well as simple desktop displays for providing visual feedback. The instrument sounds are synthesized in real-time using physical sound modeling. }
 }
 
@@ -69,7 +71,9 @@
   address = {Vancouver, BC, Canada},
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176840},
-  url = {http://www.nime.org/proceedings/2005/nime2005_017.pdf}
+  url = {http://www.nime.org/proceedings/2005/nime2005_017.pdf},
+  keywords = {Collaboration, improvisation, gestrual handheld controllers, novices, mapping},
+  abstract = {The iltur system features a novel method of interaction between expert and novice musicians through a set of musical controllers called Beatbugs. Beatbug players can record live musical input from MIDI and acoustic instruments and respond by transforming the recorded material in real-time, creating motif-and-variation call-and-response routines on the fly. A central computer system analyzes MIDI and audio played by expert players and allows novice Beatbug players to personalize the analyzed material using a variety of transformation algorithms. This paper presents the motivation for developing the iltur system, followed by a brief survey of pervious and related work that guided the definition of the project’s goals. We then present the hardware and software approaches that were taken to address these goals, as well as a couple of compositions that were written for the system. The paper ends with a discussion based on observations of players using the iltur system and a number of suggestions for future work.}
 }
 
 @inproceedings{Jorda2005,
@@ -96,6 +100,7 @@
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176709},
   url = {http://www.nime.org/proceedings/2005/nime2005_027.pdf},
+  keywords = {Alternate controllers, musical interaction, interactive entertainment, video game industry, arcades, rhythm action, collaborative gameplay, musical performance games},
   abstract = {This paper will investigate a variety of alternate controllers that are making an impact in interactive entertainment, particularly in the video game industry. Since the late 1990's, the surging popularity of rhythmic and musical performance games in Japanese arcades has led to the development of new interfaces and alternate controllers for the consumer market worldwide. Rhythm action games such as Dance Dance Revolution, Taiko No Tatsujin (Taiko: Drum Master), and Donkey Konga are stimulating collaborative gameplay and exposing consumers to custom controllers designed specifically for musical and physical interaction. We are witnessing the emergence and acceptance of these breakthrough controllers and models for gameplay as an international cultural phenomenon penetrating the video game and toy markets in record numbers. Therefore, it is worth considering the potential benefits to developers of musical interfaces, electronic devices and alternate controllers in light of these new and emerging opportunities, particularly in the realm of video gaming, toy development, arcades, and other interactive entertainment experiences. }
 }
 
@@ -163,6 +168,7 @@
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176818},
   url = {http://www.nime.org/proceedings/2005/nime2005_050.pdf},
+  keywords = {Robotics, music, instruments, MIDI, video, interactive, networked, streaming.},
   abstract = {This paper describes an installation created by LEMUR(League of Electronic Musical Urban Robots) in January, 2005.The installation included over 30 robotic musical instrumentsand a multi-projector real-time video projection and wascontrollable and programmable over a MIDI network. Theinstallation was also controllable remotely via the Internet andcould be heard and viewed via room mics and a robotic webcam connected to a streaming server.}
 }
 
@@ -175,7 +181,9 @@
   address = {Vancouver, BC, Canada},
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176693},
-  url = {http://www.nime.org/proceedings/2005/nime2005_056.pdf}
+  url = {http://www.nime.org/proceedings/2005/nime2005_056.pdf},
+  keywords = {Teabox, Electrotap, Sensor Interface, High Speed, High Resolution, Sensors, S/PDIF},
+  abstract = {Artists have long sought after alternative controllers, sensors, and other means for controlling computer-based musical performance in real-time. Traditional techniques for transmitting the data generated by such devices typically employ the use of MIDI as the transport protocol. Recently, several devices have been developed using alternatives to MIDI, including Ethernet-based and USB-based sensor interfaces. We have designed and produced a system that uses S/PDIF as the transport mechanism for a sensor interface. This provides robust performance, together with extremely low latency and high resolution. In our system, data from all sensors is multiplexed onto the digital audio line and demultiplexed in software on the computer using standard techniques. We have written demultiplexer objects and plugins for Max/MSP and Jade, as well as a MIDI Conversion program for interapplicaton uses, while others are in the works for PD, SuperCollider, and AudioUnits.}
 }
 
 @inproceedings{Oore2005,
@@ -189,7 +197,7 @@
   doi = {10.5281/zenodo.1176794},
   url = {http://www.nime.org/proceedings/2005/nime2005_060.pdf},
   keywords = {performance, learning new instruments },
-  abstract = {When learning a classical instrument, people often eithertake lessons in which an existing body of "technique" is delivered, evolved over generations of performers, or in somecases people will "teach themselves" by watching people playand listening to existing recordings. What does one do witha complex new digital instrument?In this paper I address this question drawing on my experience in learning several very different types of sophisticatedinstruments: the Glove Talk II real-time gesture-to-speechinterface, the Digital Marionette controller for virtual 3Dpuppets, and pianos and keyboards. As the primary userof the first two systems, I have spent hundreds of hourswith Digital Marionette and Glove-Talk II, and thousandsof hours with pianos and keyboards (I continue to work asa professional musician). I will identify some of the underlying principles and approaches that I have observed duringmy learning and playing experience common to these instruments. While typical accounts of users learning new interfaces generally focus on reporting beginner's experiences, forvarious practical reasons, this is fundamentally different byfocusing on the expert's learning experience.}
+  abstract = {When learning a classical instrument, people often either take lessons in which an existing body of “technique” is de- livered, evolved over generations of performers, or in some cases people will “teach themselves” by watching people play and listening to existing recordings. What does one do with a complex new digital instrument? In this paper I address this question drawing on my expe- rience in learning several very different types of sophisticated instruments: the Glove Talk II real-time gesture-to-speech interface, the Digital Marionette controller for virtual 3D puppets, and pianos and keyboards. As the primary user of the first two systems, I have spent hundreds of hours with Digital Marionette and Glove-Talk II, and thousands of hours with pianos and keyboards (I continue to work as a professional musician). I will identify some of the under- lying principles and approaches that I have observed during my learning and playing experience common to these instru- ments. While typical accounts of users learning new inter- faces generally focus on reporting beginner’s experiences, for various practical reasons, this is fundamentally different by focusing on the expert’s learning experience.}
 }
 
 @inproceedings{Livingstone2005,
@@ -202,7 +210,8 @@
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176774},
   url = {http://www.nime.org/proceedings/2005/nime2005_065.pdf},
-  keywords = {Adaptive System, Sound Installation, Smart Interfaces, Music Robots, Spatial Music, Conscious Subconscious Interaction. }
+  keywords = {Adaptive System, Sound Installation, Smart Interfaces, Music Robots, Spatial Music, Conscious Subconscious Interaction.},
+  abstract = {Haptic and Gestural interfaces offer new and novel ways of interacting with and creating new musical forms. Increasingly it is the integration of these interfaces with more complex adaptive systems or dynamically variable social contexts that provide significant opportunities for socially mediated composition through conscious and subconscious interaction. This paper includes a brief comparative survey of related works and articulates the design process and interaction modes or ‘play states’ for the Orb3 interface – 3 wireless mobile globes that collect and share environmental data and user interactions to synthesize and diffuse sound material in real time, a ‘social’ group of composer and listener objects. The physical interfaces are integrated into a portable 8 channel auditory sphere for collaborative interaction but can also be integrated with large-scale social environments, such as atria and other public spaces with embedded sound systems.}
 }
 
 @inproceedings{Essl2005,
@@ -214,7 +223,8 @@
   address = {Vancouver, BC, Canada},
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176737},
-  url = {http://www.nime.org/proceedings/2005/nime2005_070.pdf}
+  url = {http://www.nime.org/proceedings/2005/nime2005_070.pdf},
+  abstract = {The Scrubber is a general controller for friction-induced sound. Allowing the user to engage in familiar gestures and feel- ing actual friction, the synthesized sound gains an evocative nature for the performer and a meaningful relationship between gesture and sound for the audience. It can control a variety of sound synthesis algorithms of which we demonstrate examples based on granular synthesis, wave-table synthesis and physically informed modeling.} 
 }
 
 @inproceedings{Topper2005,
@@ -226,7 +236,8 @@
   address = {Vancouver, BC, Canada},
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176830},
-  url = {http://www.nime.org/proceedings/2005/nime2005_076.pdf}
+  url = {http://www.nime.org/proceedings/2005/nime2005_076.pdf},
+  abstract = {WISEAR (Wireless Sensor Array) is a Linux based Embeddedx86 TS-5600 SBC (Single Board Computer) specifically configured for use with music, dance and video performance technologies. The device offers a general purpose solution to many sensor and gestural controller problems. Much like the general purpose CPU, which resolved many issues of its predecessor (ie., the special purpose DSP chip), the WISEAR box attempts to move beyond custom made BASIC stamp projects that are often created on a per-performance basis and rely heavily on MIDI. WISEAR is both lightweight and wireless. Unlike several commercial alternatives, it is also a completely open source project.  PAIR (Partnering Analysis in Real Time) exploits the power of WISEAR and revisits the potential of hardware-based systems for real-time measurement of bodily movement. Our goal was to create a robust yet adaptable system that could attend to both general and precise aspects of performer interaction. Though certain commonalities with existing hardware systems exist, our PAIR system takes a fundamentally different approach by focusing specifically on the interaction of two or more dancers.}
 }
 
 @inproceedings{Dannenberg2005,
@@ -268,7 +279,7 @@
   doi = {10.5281/zenodo.1176800},
   url = {http://www.nime.org/proceedings/2005/nime2005_089.pdf},
   keywords = {Graphical user interface, real-time performance, map, dynamic routing },
-  abstract = {This paper describes DspMap, a graphical user interface (GUI)designed to assist the dynamic routing of signal generators andmodifiers currently being developed at the International Academyof Media Arts & Sciences. Instead of relying on traditional boxand-line approaches, DspMap proposes a design paradigm whereconnections are determined by the relative positions of the variouselements in a single virtual space.}
+  abstract = {This paper describes DspMap, a graphical user interface (GUI)designed to assist the dynamic routing of signal generators andmodifiers currently being developed at the International Academy of Media Arts \& Sciences. Instead of relying on traditional boxand-line approaches, DspMap proposes a design paradigm whereconnections are determined by the relative positions of the variouselements in a single virtual space.}
 }
 
 @inproceedings{Scavone2005,
@@ -309,7 +320,8 @@
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176701},
   url = {http://www.nime.org/proceedings/2005/nime2005_101.pdf},
-  keywords = {computational geometry,design,design support,high-level control,interpolation,mapping,of interpo-,this section reviews related,user interface,work in the field}
+  keywords = {computational geometry,design,design support,high-level control,interpolation,mapping,of interpo-,this section reviews related,user interface,work in the field},
+  abstract = {This report describes The Metasurface – a mapping interface supporting interactive design of two-to-many mappings through the placement and interpolation of parameter snapshots on a plane. The Metasurface employs natural neighbour interpolation, a local interpolation method based on Voronoi tessellation, to interpolate between parameter snapshots. Compared to global field based methods, natural neighbour interpolation offers increased predictability and the ability to represent multi-scale surfaces. An implementation of the Metasurface in the AudioMulch software environment is presented and key architectural features of AudioMulch which facilitate this implementation are discussed.}
 }
 
 @inproceedings{Silva2005,
@@ -336,7 +348,8 @@
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176804},
   url = {http://www.nime.org/proceedings/2005/nime2005_109.pdf},
-  keywords = {Haptic, interaction, sound, music, control, installation. }
+  keywords = {Haptic, interaction, sound, music, control, installation. },
+  abstract = {The PHASE project is a research project devoted to the study and the realization of systems of multi-modal interaction for generation, handling and control of sound and music. Supported by the network RIAM (Recherche et Innovation en Audiovisuel et Multim\'{e}dia), it was carried out by the CEA-LIST for haptic research, Haption for the realization of the haptic device, Ondim for integration and visual realization and Ircam for research and realization about sound, music and the metaphors for interaction. The integration of the three modalities offers completely innovative capacities for interaction. The objectives are scientific, cultural and educational. Finally, an additional objective was to test such a prototype system, including its haptic arm, in real conditions for general public and over a long duration in order to measure its solidity, its reliability and its interest for users. Thus, during the last three months of the project, a demonstrator was presented and evaluated in a museum in Paris, in the form of an interactive installation offering the public a musical game. Different from a video game, the aim is not to animate the pixels on the screen but to play music and to incite musical awareness.}
 }
 
 @inproceedings{Levin2005a,
@@ -364,7 +377,7 @@
   doi = {10.5281/zenodo.1176844},
   url = {http://www.nime.org/proceedings/2005/nime2005_121.pdf},
   keywords = {Personified Expression, Singing Voice Morphing, Voice Ex- pressivity, Hand-puppet Interface },
-  abstract = {The HandySinger system is a personified tool developedto naturally express a singing voice controlled by the gestures of a hand puppet. Assuming that a singing voice is akind of musical expression, natural expressions of the singingvoice are important for personification. We adopt a singingvoice morphing algorithm that effectively smoothes out thestrength of expressions delivered with a singing voice. Thesystem's hand puppet consists of a glove with seven bendsensors and two pressure sensors. It sensitively capturesthe user's motion as a personified puppet's gesture. Tosynthesize the different expressional strengths of a singingvoice, the ``normal'' (without expression) voice of a particular singer is used as the base of morphing, and three different expressions, ``dark,'' ``whisper'' and ``wet,'' are used asthe target. This configuration provides musically expressedcontrols that are intuitive to users. In the experiment, weevaluate whether 1) the morphing algorithm interpolatesexpressional strength in a perceptual sense, 2) the handpuppet interface provides gesture data at sufficient resolution, and 3) the gestural mapping of the current systemworks as planned.}
+  abstract = {The HandySinger system is a personified tool developed to naturally express a singing voice controlled by the gestures of a hand puppet. Assuming that a singing voice is a kind of musical expression, natural expressions of the singing voice are important for personification. We adopt a singing voice morphing algorithm that effectively smoothes out the strength of expressions delivered with a singing voice. The system’s hand puppet consists of a glove with seven bend sensors and two pressure sensors. It sensitively captures the user’s motion as a personified puppet’s gesture. To synthesize the different expressional strengths of a singing voice, the “normal” (without expression) voice of a particular singer is used as the base of morphing, and three different expressions, “dark,” “whisper” and “wet,” are used as the target. This configuration provides musically expressed controls that are intuitive to users. In the experiment, we evaluate whether 1) the morphing algorithm interpolates expressional strength in a perceptual sense, 2) the handpuppet interface provides gesture data at sufficient resolution, and 3) the gestural mapping of the current system works as planned.}
 }
 
 @inproceedings{Funk2005,
@@ -452,7 +465,7 @@
 }
 
 @inproceedings{Pellarin2005,
-  author = {Pellarin, Lars and B\''{o}ttcher, Niels and Olsen, Jakob M. and Gregersen, Ole and Serafin, Stefania and Guglielmi, Michel},
+  author = {Pellarin, Lars and B\"{o}ttcher, Niels and Olsen, Jakob M. and Gregersen, Ole and Serafin, Stefania and Guglielmi, Michel},
   title = {Connecting Strangers at a Train Station},
   pages = {152--155},
   booktitle = {Proceedings of the International Conference on New Interfaces for Musical Expression},
@@ -461,7 +474,8 @@
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176798},
   url = {http://www.nime.org/proceedings/2005/nime2005_152.pdf},
-  keywords = {Motion tracking, mapping strategies, public installation, multiple participants music interfaces. }
+  keywords = {Motion tracking, mapping strategies, public installation, multiple participants music interfaces. },
+  abstract = {In this paper we describe a virtual instrument or a performance space, placed at H{\o}je T{\aa}strup train station in Denmark, which is meant to establish communicative connections between strangers, by letting users of the system create soundscapes together across the rails. We discuss mapping strategies and complexity and suggest a possible solution for a final instance of our interactive musical performance system.}
 }
 
 @inproceedings{Schiemer2005,
@@ -516,6 +530,7 @@
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176691},
   url = {http://www.nime.org/proceedings/2005/nime2005_168.pdf},
+  keywords = {Visceral control, sample manipulation, Bluetooth®, metaphor, remutualizing instrument, Human Computer Interaction.},
   abstract = {This paper describes the development, function andperformance contexts of a digital musical instrument called "boomBox". The instrument is a wireless, orientation-awarelow-frequency, high-amplitude human motion controller forlive and sampled sound. The instrument has been used inperformance and sound installation contexts. I describe someof what I have learned from the project herein.}
 }
 
@@ -528,7 +543,8 @@
   address = {Vancouver, BC, Canada},
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176776},
-  url = {http://www.nime.org/proceedings/2005/nime2005_172.pdf}
+  url = {http://www.nime.org/proceedings/2005/nime2005_172.pdf},
+  abstract = {Using a wah-wah pedal guitar is something guitar players have to learn. Recently, more intuitive ways to control such effect have been proposed. In this direction, the Wahwactor system controls a wah-wah transformation in real-time using the guitar player’s voice, more precisely, using the performer [wa-wa] utterances. To come up with this system, different vocal features derived from spectral analysis have been studied as candidates for being used as control parameters. This paper details the results of the study and presents the implementation of the whole system.}
 }
 
 @inproceedings{Carter2005,
@@ -556,7 +572,7 @@
   doi = {10.5281/zenodo.1176699},
   url = {http://www.nime.org/proceedings/2005/nime2005_180.pdf},
   keywords = {head movements, music controllers, interface design, input devices },
-  abstract = {Bangarama is a music controller using headbanging as the primaryinteraction metaphor. It consists of a head-mounted tilt sensor and aguitar-shaped controller that does not require complex finger positions. We discuss the specific challenges of designing and buildingthis controller to create a simple, yet responsive and playable instrument, and show how ordinary materials such as plywood, tinfoil, and copper wire can be turned into a device that enables a fun,collaborative music-making experience.}
+  abstract = {Bangarama is a music controller using headbanging as the primary interaction metaphor. It consists of a head-mounted tilt sensor and aguitar-shaped controller that does not require complex finger positions. We discuss the specific challenges of designing and building this controller to create a simple, yet responsive and playable instrument, and show how ordinary materials such as plywood, tinfoil, and copper wire can be turned into a device that enables a fun, collaborative music-making experience.}
 }
 
 @inproceedings{Barbosa2005,
@@ -570,9 +586,7 @@
   doi = {10.5281/zenodo.1176697},
   url = {http://www.nime.org/proceedings/2005/nime2005_184.pdf},
   keywords = {Network Music Instruments; Latency in Real-Time Performance; Interface-Decoupled Electronic Musical Instruments; Behavioral Driven Interfaces; Collaborative Remote Music Performance; },
-  abstract = {In recent years Computer Network-Music has increasingly captured the attention of the Computer Music Community. With the advent of Internet communication, geographical displacement amongst the participants of a computer mediated music performance achieved world wide extension. However, when established over long distance networks, this form of musical communication has a fundamental problem: network latency (or net-delay) is an impediment for real-time collaboration. From a recent study, carried out by the ,
-,
-authors, a relation between network latency tolerance and Music Tempo was established. This result emerged from an experiment, in which simulated network latency conditions were applied to the performance of different musicians playing jazz standard tunes. The Public Sound Objects (PSOs) project is web-based shared musical space, which has been an experimental framework to implement and test different approaches for on-line music communication. This paper describe features implemented in the latest version of the PSOs system, including the notion of a network-music instrument incorporating latency as a software function, by dynamically adapting its tempo to the communication delay measured in real-time. }
+  abstract = {In recent years Computer Network-Music has increasingly captured the attention of the Computer Music Community. With the advent of Internet communication, geographical displacement amongst the participants of a computer mediated music performance achieved world wide extension. However, when established over long distance networks, this form of musical communication has a fundamental problem: network latency (or net-delay) is an impediment for real-time collaboration. From a recent study, carried out by the authors, a relation between network latency tolerance and Music Tempo was established. This result emerged from an experiment, in which simulated network latency conditions were applied to the performance of different musicians playing jazz standard tunes. The Public Sound Objects (PSOs) project is web-based shared musical space, which has been an experimental framework to implement and test different approaches for on-line music communication. This paper describe features implemented in the latest version of the PSOs system, including the notion of a network-music instrument incorporating latency as a software function, by dynamically adapting its tempo to the communication delay measured in real-time.}
 }
 
 @inproceedings{Villar2005,
@@ -586,7 +600,7 @@ authors, a relation between network latency tolerance and Music Tempo was establ
   doi = {10.5281/zenodo.1176834},
   url = {http://www.nime.org/proceedings/2005/nime2005_188.pdf},
   keywords = {tangible interface, rearrangeable interface, midi controllers },
-  abstract = {We present the Pin&Play&Perform system: an interface inthe form of a tablet on which a number of physical controlscan be added, removed and arranged on the fly. These controls can easily be mapped to existing music sofware usingthe MIDI protocol. The interface provides a mechanism fordirect manipulation of application parameters and eventsthrough a set of familiar controls, while also encouraging ahigh degree of customisation through the ability to arrange,rearrange and annotate the spatial layout of the interfacecomponents on the surface of the tablet.The paper describes how we have realized this concept using the Pin&Play technology. As an application example, wedescribe our experiences in using our interface in conjunction with Propellerheads' Reason, a popular piece of musicsynthesis software.}
+  abstract = {We present the Pin\&Play\&Perform system: an interface inthe form of a tablet on which a number of physical controlscan be added, removed and arranged on the fly. These controls can easily be mapped to existing music sofware usingthe MIDI protocol. The interface provides a mechanism fordirect manipulation of application parameters and eventsthrough a set of familiar controls, while also encouraging ahigh degree of customisation through the ability to arrange,rearrange and annotate the spatial layout of the interfacecomponents on the surface of the tablet.The paper describes how we have realized this concept using the Pin\&Play technology. As an application example, wedescribe our experiences in using our interface in conjunction with Propellerheads' Reason, a popular piece of musicsynthesis software.}
 }
 
 @inproceedings{Birnbaum2005,
@@ -599,7 +613,8 @@ authors, a relation between network latency tolerance and Music Tempo was establ
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176707},
   url = {http://www.nime.org/proceedings/2005/nime2005_192.pdf},
-  keywords = {design space analysis,human-computer interaction,interfaces for musical expression,new}
+  keywords = {design space analysis,human-computer interaction,interfaces for musical expression,new},
+  abstract = {While several researchers have grappled with the problem of comparing musical devices across performance, installation, and related contexts, no methodology yet exists for producing holistic, informative visualizations for these devices. Drawing on existing research in performance interaction, human-computer interaction, and design space analysis, the authors propose a dimension space representation that can be adapted for visually displaying musical devices. This paper illustrates one possible application of the dimension space to existing performance and interaction systems, revealing its usefulness both in exposing patterns across existing musical devices and aiding in the design of new ones.}
 }
 
 @inproceedings{Wang2005a,
@@ -640,6 +655,7 @@ authors, a relation between network latency tolerance and Music Tempo was establ
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176766},
   url = {http://www.nime.org/proceedings/2005/nime2005_204.pdf},
+  keywords = {time design, conceptual models of time, design spaces, interactive music exhibits, engineering music systems},
   abstract = {Discussion of time in interactive computer music systems engineering has been largely limited to data acquisition rates and latency.Since music is an inherently time-based medium, we believe thattime plays a more important role in both the usability and implementation of these systems. In this paper, we present a time designspace, which we use to expose some of the challenges of developing computer music systems with time-based interaction. Wedescribe and analyze the time-related issues we encountered whilstdesigning and building a series of interactive music exhibits thatfall into this design space. These issues often occur because ofthe varying and sometimes conflicting conceptual models of timein the three domains of user, application (music), and engineering.We present some of our latest work in conducting gesture interpretation and frameworks for digital audio, which attempt to analyzeand address these conflicts in temporal conceptual models.}
 }
 
@@ -653,7 +669,8 @@ authors, a relation between network latency tolerance and Music Tempo was establ
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176764},
   url = {http://www.nime.org/proceedings/2005/nime2005_208.pdf},
-  keywords = {Reconfigurable, Sensors, Computer Music }
+  keywords = {Reconfigurable, Sensors, Computer Music },
+  abstract = {This paper reports our recent development on a reconfigurable user interface. We created a system that consists of a dial type controller ‘Spinner’, and the GUI (Graphical User Interface) objects for the Max/MSP environment[1]. One physical controller corresponds to one GUI controller on a PC’s display device, and a user can freely change the connection on the fly (i.e. associate the physical controller to another GUI controller). Since the user interface on the PC side is running on the Max/MSP environment that has high flexibility, a user can freely reconfigure the layout of GUI controllers. A single ‘Spinner’ control device consists of a rotary encoder with a push button to count rotations and a photo IC to detect specific patterns from the GUI objects to identify. Since ‘Spinner’ features a simple identification method, it is capable of being used with normal display devices like LCD (Liquid Crystal Display) or a CRT (Cathode Ray Tube) and so on. A user can access multiple ‘Spinner’ devices simultaneously. By using this system, a user can build a reconfigurable user interface.}
 }
 
 @inproceedings{Magnusson2005,
@@ -680,6 +697,7 @@ authors, a relation between network latency tolerance and Music Tempo was establ
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176792},
   url = {http://www.nime.org/proceedings/2005/nime2005_216.pdf},
+  keywords = {Brain-Computer Interface, BCI, Electroencephalogram, EEG, brainwaves, music and the brain, interactive music systems.},
   abstract = { Musicians and composers have been using brainwaves as generative sources in music for at least 40 years and the possibility of a brain-computer interface for direct communication and control was first seriously investigated in the early 1970s. Work has been done by many artists and technologists in the intervening years to attempt to control music systems with brainwaves and --- indeed --- many other biological signals. Despite the richness of EEG, fMRI and other data which can be read from the human brain, there has up to now been only limited success in translating the complex encephalographic data into satisfactory musical results. We are currently pursuing research which we believe will lead to the possibility of direct brain-computer interfaces for rich and expressive musical control. This report will outline the directions of our current research and results. }
 }
 
@@ -734,7 +752,9 @@ authors, a relation between network latency tolerance and Music Tempo was establ
   address = {Vancouver, BC, Canada},
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176842},
-  url = {http://www.nime.org/proceedings/2005/nime2005_232.pdf}
+  url = {http://www.nime.org/proceedings/2005/nime2005_232.pdf},
+  keywords = {Musical experience, non-verbal test techniques, musical parameters.},
+  abstract = {A typical experiment design within the field of music psychology is playing music to a test subject who listens and reacts – most often by verbal means. One limitation of this kind of test is the inherent difficulty of measuring an emotional reaction in a laboratory setting. This paper describes the design, functions and possible uses of the software tool REMUPP (Relations between musical parameters and perceived properties), designed for investigating various aspects of musical experience. REMUPP allows for non-verbal examination of selected musical parameters (such as tonality, tempo, timbre, articulation, volume, register etc.) in a musical context. The musical control is put into the hands of the subject, introducing an element of creativity and enhancing the sense of immersion. Information acquired with REMUPP can be output as numerical data for statistical analysis, but the tool is also suited for the use with more qualitatively oriented methods.}
 }
 
 @inproceedings{Cook2005,
@@ -762,11 +782,7 @@ authors, a relation between network latency tolerance and Music Tempo was establ
   doi = {10.5281/zenodo.1176762},
   url = {http://www.nime.org/proceedings/2005/nime2005_238.pdf},
   keywords = {Score generation, Jitter. },
-  abstract = {The ,
-,
-author describes a recent composition for piano andcomputer in which the score performed by the pianist, readfrom a computer monitor, is generated in real-time from avocabulary of predetermined scanned score excerpts. The,
-,
-author outlines the algorithm used to choose and display aparticular excerpt and describes some of the musicaldifficulties faced by the pianist in a performance of the work. }
+  abstract = {The author describes a recent composition for piano and computer in which the score performed by the pianist, read from a computer monitor, is generated in real-time from a vocabulary of predetermined scanned score excerpts. The author outlines the algorithm used to choose and display a particular excerpt and describes some of the musical difficulties faced by the pianist in a performance of the work.}
 }
 
 @inproceedings{Baird2005,
@@ -807,7 +823,8 @@ author outlines the algorithm used to choose and display aparticular excerpt and
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176848},
   url = {http://www.nime.org/proceedings/2005/nime2005_244.pdf},
-  keywords = {Musical controller, sensate surface, mapping system }
+  keywords = {Musical controller, sensate surface, mapping system },
+  abstract = {This paper presents the ‘Bean’, a novel controller employing a multi-touch sensate surface in a compound curve shape. The design goals, construction, and mapping system are discussed, along with a retrospective from a previous, similar design.}
 }
 
 @inproceedings{Lugo2005,
@@ -848,12 +865,13 @@ author outlines the algorithm used to choose and display aparticular excerpt and
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176721},
   url = {http://www.nime.org/proceedings/2005/nime2005_250.pdf},
-  keywords = {Musical Controller, Collaborative Control, Haptic Interfaces }
+  keywords = {Musical Controller, Collaborative Control, Haptic Interfaces },
+  abstract = {OROBORO is a novel collaborative controller which focuses on musical performance as social experience by exploring synchronized actions of two musicians operating a single instrument. Each performer uses two paddle mechanisms – one for hand orientation sensing and one for servo-motor actuated feedback. We introduce a haptic mirror in which the movement of one performer’s sensed hand is used to induce movement of the partner’s actuated hand and vice versa. We describe theoretical motivation, and hardware/software implementation.}
 }
 
 @inproceedings{Rodriguez2005,
   author = {Rodr\'{\i}guez, David and Rodr\'{\i}guez, Iv\'{a}n},
-  title = {VIFE \_ alpha v.01 Real-time Visual Sound Installation performed by Glove-Gesture},
+  title = {VIFE \_alpha v.01 Real-time Visual Sound Installation performed by Glove-Gesture},
   pages = {252--253},
   booktitle = {Proceedings of the International Conference on New Interfaces for Musical Expression},
   year = {2005},
@@ -862,7 +880,7 @@ author outlines the algorithm used to choose and display aparticular excerpt and
   doi = {10.5281/zenodo.1176806},
   url = {http://www.nime.org/proceedings/2005/nime2005_252.pdf},
   keywords = {Synaesthesia, 3D render, new reality, virtual interface, creative interaction, sensors. },
-  abstract = {We present a Virtual Interface to Feel Emotions called VIFE _alpha v.01 (Virtual Interface to Feel Emotions). The work investigates the idea of Synaesthesia and her enormous possibilities creating new realities, sensations and zones where the user can find new points of interaction. This interface allows the user to create sonorous and visual compositions in real time. 6 three-dimensional sonorous forms are modified according to the movements of the user. These forms represent sonorous objects that respond to this by means of sensorial stimuli. Multiple combinations of colors and sound effects superpose to an a the others to give rise to a unique experience. }
+  abstract = {We present a Virtual Interface to Feel Emotions called VIFE {\_}alpha v.01 (Virtual Interface to Feel Emotions). The work investigates the idea of Synaesthesia and her enormous possibilities creating new realities, sensations and zones where the user can find new points of interaction. This interface allows the user to create sonorous and visual compositions in real time. 6 three-dimensional sonorous forms are modified according to the movements of the user. These forms represent sonorous objects that respond to this by means of sensorial stimuli. Multiple combinations of colors and sound effects superpose to an a the others to give rise to a unique experience.}
 }
 
 @inproceedings{Hindman2005,
@@ -888,7 +906,9 @@ author outlines the algorithm used to choose and display aparticular excerpt and
   address = {Vancouver, BC, Canada},
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176832},
-  url = {http://www.nime.org/proceedings/2005/nime2005_256.pdf}
+  url = {http://www.nime.org/proceedings/2005/nime2005_256.pdf},
+  keywords = {Music control, haptic feedback, physical interaction design, Input/output devices, interactive systems, haptic I/O},
+  abstract = {Pluck, ring, rub, bang, strike, and squeeze are all simple gestures used in controlling music. A single motor/encoder plus a force-sensor has proved to be a useful platform for experimenting with haptic feedback in controlling computer music. The surprise is that the “best” haptics (precise, stable) may not be the most “musical”.}
 }
 
 @inproceedings{Eaton2005,
@@ -984,7 +1004,9 @@ author outlines the algorithm used to choose and display aparticular excerpt and
   address = {Vancouver, BC, Canada},
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176752},
-  url = {http://www.nime.org/proceedings/2005/nime2005_270.pdf}
+  url = {http://www.nime.org/proceedings/2005/nime2005_270.pdf},
+  keywords = {Interactive sound installation, collaborative work, sound processing, acoustic source localization.},
+  abstract = {INTRIUM is an interactive sound installation exploring the inside vibration of the atrium. A certain number of architectural elements are fitted with acoustic sensors in order to capture the vibration they produce when they are manipulated or touched by hands. This raw sound is further processed in real-time, allowing the participants to create a sonic landscape in the atrium, as the result of a collaborative and collective work between them.}
 }
 
 @inproceedings{Socolofsky2005,
@@ -1024,7 +1046,9 @@ author outlines the algorithm used to choose and display aparticular excerpt and
   address = {Vancouver, BC, Canada},
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176788},
-  url = {http://www.nime.org/proceedings/2005/nime2005_273.pdf}
+  url = {http://www.nime.org/proceedings/2005/nime2005_273.pdf},
+  keywords = {Footsteps, body action, interactive, visualization, simple and reliable interface, contact microphone, sound playground},
+  abstract = {'Hop Step Junk' is an interactive sound installation that creates audio and visual representations of the audience's footsteps. The sound of a footstep is very expressive. Depending on one's weight, clothing and gate, a footstep can sound quite different. The period between steps defines one's personal rhythm. The sound output of 'Hop Step Junk' is wholly derived from the audience's footsteps. 'Hop Step Junk' creates a multi-generational playground, an instrument that an audience can easily play.}
 }
 
 @inproceedings{Deutscher2005,
@@ -1036,6 +1060,7 @@ author outlines the algorithm used to choose and display aparticular excerpt and
   address = {Vancouver, BC, Canada},
   issn = {2220-4806},
   doi = {10.5281/zenodo.1176733},
-  url = {http://www.nime.org/proceedings/2005/nime2005_274.pdf}
+  url = {http://www.nime.org/proceedings/2005/nime2005_274.pdf},
+  keywords = {Mediascape, sound spatialization, interactive art, Beluga whale}
 }
 


### PR DESCRIPTION
- Escape characters in abstract text where required
- Checked by generating a PDF using `pdflatex` and `bibtex`  