### PR TITLE
Correct author names/surnames in NIME 2026 proceedings

### DIFF
--- a/paper_proceedings/nime2026.bib
+++ b/paper_proceedings/nime2026.bib
@@ -1117,7 +1117,7 @@
 }
 
 @inproceedings{nime2026_58,
-  author = {Domenico Stefani and Francesco Dal Rì and Luca Turchet},
+  author = {Domenico Stefani and Dal Rí, Francesco Ardan and Luca Turchet},
   title = {Probing Latent Space Interactions with Real-time Generative Audio Models Through a Physical Controller},
   pages = {492--499},
   booktitle = {Proceedings of the International Conference on New Interfaces for Musical Expression},
@@ -1290,7 +1290,7 @@
 }
 
 @inproceedings{nime2026_67,
-  author = {Francesco Manenti and Raul Masu and Francesco Ardan Dal Rì and Luca Turchet},
+  author = {Francesco Manenti and Raul Masu and Dal Rí, Francesco Ardan and Luca Turchet},
   title = {Repertoire-Centred Design: Mechanical Augmentations in Digital Lutherie for Acoustic Musical Instruments},
   pages = {568--576},
   booktitle = {Proceedings of the International Conference on New Interfaces for Musical Expression},


### PR DESCRIPTION
Changed “Francesco Ardan Dal Rí” to “Dal Rí, Francesco Ardan” so that the compound family name is parsed correctly as "Dal Rí, F. A." rather than "Rí, F. A. D."