### PR TITLE
Correct author names/surnames in NIME 2025 proceedings

### DIFF
--- a/paper_proceedings/nime2025.bib
+++ b/paper_proceedings/nime2025.bib
@@ -564,7 +564,7 @@
 }
 
 @inproceedings{nime2025_32,
-  author = {Isaac Clarke and Francesco Ardan  Dal Rí and Raul Masu},
+  author = {Isaac Clarke and Dal Rí, Francesco Ardan and Raul Masu},
   title = {Longevity of Deep Generative Models in NIME: Challenges and Practices for Reactivation},
   pages = {224--230},
   booktitle = {Proceedings of the International Conference on New Interfaces for Musical Expression},
@@ -1261,7 +1261,7 @@
 }
 
 @inproceedings{nime2025_70,
-  author = {Hanyu Qu and Francesco Dal Rí  and Hao Zou and Hanqing Zhou and Raul Masu},
+  author = {Hanyu Qu and Dal Rí, Francesco Ardan and Hao Zou and Hanqing Zhou and Raul Masu},
   title = {O – : An Epistemic DMI for Cross-Cultural Reflection on Time and Music},
   pages = {481--488},
   booktitle = {Proceedings of the International Conference on New Interfaces for Musical Expression},


### PR DESCRIPTION
Changed “Francesco Ardan Dal Rí” to “Dal Rí, Francesco Ardan” so that the compound family name is parsed correctly as "Dal Rí, F. A." rather than "Rí, F. A. D."