### PR TITLE
Correct author names/surnames in NIME 2024 proceedings

### DIFF
--- a/paper_proceedings/nime2024.bib
+++ b/paper_proceedings/nime2024.bib
@@ -1420,7 +1420,7 @@ Visual Storytelling},
 }
 
 @inproceedings{nime2024_77,
-  author = {Francesco Manenti and Francesco Ardan Dal Rì},
+  author = {Francesco Manenti and Dal Rí, Francesco Ardan},
   title = {Accessibility of Graphic Scores: Design and Exploration of Tactile Supports for Blind People},
   pages = {530--535},
   booktitle = {Proceedings of the International Conference on New Interfaces for Musical Expression},


### PR DESCRIPTION
Changed “Francesco Ardan Dal Rí” to “Dal Rí, Francesco Ardan” so that the compound family name is parsed correctly as "Dal Rí, F. A." rather than "Rí, F. A. D."