### PR TITLE
Correct author names/surnames in NIME 2023 proceedings

### DIFF
--- a/paper_proceedings/nime2023.bib
+++ b/paper_proceedings/nime2023.bib
@@ -350,7 +350,7 @@ critical self-reflection of the research and outreach practices among developers
 }
 
 @inproceedings{nime2023_20,
-  author = {Francesco Dal Rì and Francesca Zanghellini and Raul Masu},
+  author = {Dal Rí, Francesco Ardan and Francesca Zanghellini and Raul Masu},
   title = {Sharing the Same Sound: Reflecting on Interactions between a Live Coder and a Violinist},
   pages = {147--154},
   booktitle = {Proceedings of the International Conference on New Interfaces for Musical Expression},


### PR DESCRIPTION
Changed “Francesco Ardan Dal Rí” to “Dal Rí, Francesco Ardan” so that the compound family name is parsed correctly as "Dal Rí, F. A." rather than "Rí, F. A. D."