### PR TITLE
Correct author names/surnames in NIME 2022 proceedings

### DIFF
--- a/paper_proceedings/nime2022.bib
+++ b/paper_proceedings/nime2022.bib
@@ -601,7 +601,7 @@ LATAM and the particular challenges that practitioners face emerging from their 
  address = {Auckland, New Zealand},
  articleno = {36},
  track = {Papers},
- author = {R{\`i}, Francesco Ardan Dal and Masu, Raul},
+ author = {Dal Rí, Francesco Ardan and Masu, Raul},
  booktitle = {Proceedings of the International Conference on New Interfaces for Musical Expression},
  editor = {Andrew McPherson and Emma Frid},
  doi = {10.21428/92fbeb44.828b6114},


### PR DESCRIPTION
Changed “Rí, Francesco Ardan Dal” to “Dal Rí, Francesco Ardan” so that the compound family name is parsed correctly as "Dal Rí, F. A." rather than "Rí, F. A. D."